### PR TITLE
Add chunk_mode for on-the-fly grid chunking + wiki updates

### DIFF
--- a/data/mdc2025/pbi_sequence.json
+++ b/data/mdc2025/pbi_sequence.json
@@ -4,11 +4,13 @@
         "dsconf": "MDC2025ai",
         "fcl": "Production/JobConfig/primary/NoPrimaryPBISequence.fcl",
         "input_data": {
-            "PBI_Normal_33344.txt": 1
+            "/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/PBI_Normal_33344.txt": {
+                "chunk_lines": 1000
+            }
         },
         "run": 1430,
         "owner": "mu2e",
-        "inloc": "dir:/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/",
+        "inloc": "none",
         "outloc": {"*.art": "tape"},
         "simjob_setup": "/cvmfs/mu2e.opensciencegrid.org/Musings/SimJob/MDC2025ai/setup.sh",
         "fcl_overrides": {
@@ -21,11 +23,13 @@
         "dsconf": "MDC2025ai",
         "fcl": "Production/JobConfig/primary/NoPrimaryPBISequence.fcl",
         "input_data": {
-            "PBI_Pathological_33344.txt": 1
+            "/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/PBI_Pathological_33344.txt": {
+                "chunk_lines": 1000
+            }
         },
         "run": 1430,
         "owner": "mu2e",
-        "inloc": "dir:/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/",
+        "inloc": "none",
         "outloc": {"*.art": "tape"},
         "simjob_setup": "/cvmfs/mu2e.opensciencegrid.org/Musings/SimJob/MDC2025ai/setup.sh",
         "fcl_overrides": {

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2164,6 +2164,109 @@ class TestEventIdPerIndex(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# N+3. json2jobdef._configure_chunk_mode — chunk-on-grid submit-side logic
+# ---------------------------------------------------------------------------
+
+class TestConfigureChunkMode(unittest.TestCase):
+    """Submit-side logic for `input_data = {<path>: {"chunk_lines": N}}`.
+
+    Counts lines, computes njobs=ceil(lines/N), records chunk_mode
+    metadata in config, and auto-injects the `source.fileNames`
+    fcl_override so every job's FCL references the (per-worker-local)
+    chunk file.
+    """
+
+    def _make_source(self, nlines):
+        import tempfile
+        f = tempfile.NamedTemporaryFile('w', delete=False, suffix='.txt')
+        for i in range(nlines):
+            f.write(f"{i}\n")
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def _base_config(self, src, chunk_lines):
+        return {
+            "desc": "TestDesc",
+            "dsconf": "TestConf",
+            "owner": "mu2e",
+            "input_data": {src: {"chunk_lines": chunk_lines}},
+        }
+
+    def test_computes_njobs_exactly_divisible(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=5000)
+        cfg = self._base_config(src, chunk_lines=1000)
+        _configure_chunk_mode(cfg)
+        self.assertEqual(cfg['njobs'], 5)
+
+    def test_computes_njobs_with_remainder(self):
+        # 25438 / 1000 = 25 full chunks + 1 short → 26 jobs
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=25438)
+        cfg = self._base_config(src, chunk_lines=1000)
+        _configure_chunk_mode(cfg)
+        self.assertEqual(cfg['njobs'], 26)
+
+    def test_records_chunk_mode_metadata(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=100)
+        cfg = self._base_config(src, chunk_lines=40)
+        _configure_chunk_mode(cfg)
+        cm = cfg['chunk_mode']
+        self.assertEqual(cm['source'], src)
+        self.assertEqual(cm['lines'], 40)
+        self.assertEqual(cm['local_filename'], 'chunk.txt')
+
+    def test_auto_injects_source_filenames_override(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=100)
+        cfg = self._base_config(src, chunk_lines=50)
+        _configure_chunk_mode(cfg)
+        self.assertEqual(cfg['fcl_overrides']['source.fileNames'], ['chunk.txt'])
+
+    def test_does_not_clobber_existing_source_filenames_override(self):
+        # setdefault: if user set source.fileNames already, respect it.
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=100)
+        cfg = self._base_config(src, chunk_lines=50)
+        cfg['fcl_overrides'] = {'source.fileNames': ['user_chunk.txt']}
+        _configure_chunk_mode(cfg)
+        self.assertEqual(cfg['fcl_overrides']['source.fileNames'], ['user_chunk.txt'])
+
+    def test_rejects_zero_chunk_lines(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=100)
+        cfg = self._base_config(src, chunk_lines=0)
+        with self.assertRaises(ValueError):
+            _configure_chunk_mode(cfg)
+
+    def test_rejects_negative_chunk_lines(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        src = self._make_source(nlines=100)
+        cfg = self._base_config(src, chunk_lines=-5)
+        with self.assertRaises(ValueError):
+            _configure_chunk_mode(cfg)
+
+    def test_rejects_missing_source_file(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        cfg = self._base_config("/nonexistent/path/foo.txt", chunk_lines=100)
+        with self.assertRaises(ValueError):
+            _configure_chunk_mode(cfg)
+
+    def test_rejects_multiple_sources(self):
+        from utils.json2jobdef import _configure_chunk_mode
+        src1 = self._make_source(nlines=10)
+        src2 = self._make_source(nlines=20)
+        cfg = {
+            "desc": "TestDesc", "dsconf": "TestConf", "owner": "mu2e",
+            "input_data": {src1: {"chunk_lines": 5}, src2: {"chunk_lines": 5}},
+        }
+        with self.assertRaises(ValueError):
+            _configure_chunk_mode(cfg)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 

--- a/utils/jobdef.py
+++ b/utils/jobdef.py
@@ -293,8 +293,12 @@ def _validate_options_for_source_type(source_type: str, args_state: Dict) -> Non
             'allowed': []
         },
         'PBISequence': {
-            'required': ['inputs', 'merge_factor', 'run_number'],
-            'allowed': ['description', 'auto_description', 'events_per_job']
+            # inputs + merge_factor are used by `dir:` inloc workflows;
+            # chunk_mode workflows skip them entirely (per-job slice is
+            # materialized at runtime, no SAM-tracked inputs). Both valid.
+            'required': ['run_number'],
+            'allowed': ['description', 'auto_description', 'events_per_job',
+                        'inputs', 'merge_factor']
         }
     }
     
@@ -476,7 +480,17 @@ def _parse_job_args(job_args: List[str], template_path: str, config: Dict = None
         # Sequencer uniqueness comes from the input chunk basename (e.g. the
         # ".00" slot in dts.mu2e.PBINormal_33344.MDC2025ac.00.txt) — no
         # subrunkey needed.
-        if args_state['inputs_list']:
+        has_inputs = bool(args_state.get('inputs_list'))
+        has_chunk_mode = bool(config and config.get('chunk_mode'))
+        if not (has_inputs or has_chunk_mode):
+            raise ValueError(
+                "PBISequence source requires either 'inputs' + 'merge_factor' "
+                "(for SAM-tracked or dir:-mode inputs) or 'chunk_mode' "
+                "(for on-the-fly grid chunking) in the config."
+            )
+        if args_state.get('run_number') is None:
+            raise ValueError("PBISequence source requires 'run' in the config.")
+        if has_inputs:
             tbs['inputs'] = {'source.fileNames': [args_state['merge_factor'], args_state['inputs_list']]}
         tbs['event_id'] = {
             'source.runNumber': args_state['run_number'],
@@ -552,6 +566,15 @@ def _parse_job_args(job_args: List[str], template_path: str, config: Dict = None
     # across chunks, but generic — any key that takes an integer works.
     if 'event_id_per_index' in config:
         tbs['event_id_per_index'] = config['event_id_per_index']
+
+    # Handle chunk_mode — on-the-fly chunking at grid.
+    # Shape: {"source": "/cvmfs/.../file.txt", "lines": 1000,
+    #         "local_filename": "chunk.txt"}
+    # runmu2e reads this from jobpars at grid time, extracts the per-job
+    # slice, and writes it to local_filename before mu2e runs. The FCL
+    # points at local_filename via fcl_overrides (set by json2jobdef).
+    if 'chunk_mode' in config:
+        tbs['chunk_mode'] = config['chunk_mode']
 
     # Reorder TBS to match Perl order: outfiles, subrunkey, auxin, inputs, event_id, seed
     ordered_tbs = {}

--- a/utils/json2jobdef.py
+++ b/utils/json2jobdef.py
@@ -42,6 +42,48 @@ def _write_random_selection(out_f, query: str, total_needed: int, seed_source: s
         produced += 1
         idx = (idx + 1) % count
 
+def _configure_chunk_mode(config):
+    """Handle `input_data = {"<path>": {"chunk_lines": N}}`.
+
+    Doesn't pre-split. Records the source path + chunk size in
+    `config['chunk_mode']` so the tarball carries it into jobpars;
+    at grid runtime, `runmu2e` extracts the per-job slice from the
+    cvmfs source before invoking mu2e. njobs = ceil(lines/chunk_lines)
+    is computed here and written into the jobdefs_list.json entry.
+
+    Every job's FCL points at the same local filename (default:
+    `chunk.txt`) via fcl_overrides; the per-job content is created
+    fresh on the grid worker.
+    """
+    input_data = config['input_data']
+    if len(input_data) != 1:
+        raise ValueError("chunk_lines input_data must have exactly one source file")
+
+    src_str, spec = next(iter(input_data.items()))
+    src = Path(src_str)
+    if not src.is_file():
+        raise ValueError(f"chunk_lines source file not found: {src}")
+
+    chunk_lines = int(spec['chunk_lines'])
+    if chunk_lines < 1:
+        raise ValueError(f"chunk_lines must be >= 1, got {chunk_lines}")
+    with src.open() as f:
+        line_count = sum(1 for _ in f)
+    njobs = (line_count + chunk_lines - 1) // chunk_lines
+
+    local_chunk = 'chunk.txt'
+    config['njobs'] = njobs
+    config.setdefault('fcl_overrides', {})
+    config['fcl_overrides'].setdefault('source.fileNames', [local_chunk])
+    config['chunk_mode'] = {
+        'source': str(src),
+        'lines': chunk_lines,
+        'local_filename': local_chunk,
+    }
+    # No inputs.txt — there are no SAM-tracked inputs; runmu2e materializes
+    # the per-job chunk directly from cvmfs at job time.
+
+
 def _split_text_file_input(config):
     """Handle `input_data = {"<path>": {"split_lines": N}}`.
 
@@ -125,8 +167,15 @@ def _create_inputs_file(config, exclude_files=None):
     if not isinstance(input_data, dict):
         raise ValueError(f"input_data must be a dict, got {type(input_data)}")
 
-    # Text-file split shape — distinct from the SAM-based flow below.
     first_value = next(iter(input_data.values()), None)
+
+    # Chunk-on-grid shape: {"<path>": {"chunk_lines": N}}. No pre-split,
+    # no inputs.txt — runmu2e extracts each job's slice at runtime.
+    if isinstance(first_value, dict) and 'chunk_lines' in first_value:
+        _configure_chunk_mode(config)
+        return
+
+    # Text-file split shape: pre-split into chunks at submit time.
     if isinstance(first_value, dict) and 'split_lines' in first_value:
         _split_text_file_input(config)
         return
@@ -264,21 +313,27 @@ def validate_required_fields(config, required_fields=None):
 
 def determine_job_type(config):
     """Determine the job type based on config contents.
-    
+
     Returns:
+        'chunk'     - On-the-fly chunking (chunk_lines shape — no inputs.txt)
         'resampler' - Resampling jobs with resampler_name
         'merge'     - File merging jobs with input_data dict
         'mixing'    - Pileup mixing jobs with pbeam
         'stage1'    - Primary simulation jobs (cosmic, beam, etc.)
-    
-    Note: Order matters! Resampler jobs with dict input_data must be checked first.
+
+    Note: Order matters. chunk and resampler must be checked before
+    the generic `merge` fallback that only tests for a dict input_data.
     """
+    input_data = config.get('input_data')
+    if isinstance(input_data, dict):
+        first_value = next(iter(input_data.values()), None)
+        if isinstance(first_value, dict) and 'chunk_lines' in first_value:
+            return 'chunk'
     if 'resampler_name' in config:
         return 'resampler'
     elif 'pbeam' in config:
         return 'mixing'
-    # If input_data is a dict, treat as merge (extracts merge_factor from dict values)
-    elif isinstance(config.get('input_data'), dict):
+    elif isinstance(input_data, dict):
         return 'merge'
     else:
         return 'stage1'
@@ -599,6 +654,12 @@ def process_single_entry(config, json_output=True, pushout=False, no_cleanup=Tru
         # Merge jobs: simple file merging
         merge_factor = calculate_merge_factor(config)
         job_args = ['--inputs','inputs.txt','--merge-factor', str(merge_factor)]
+
+    elif job_type == 'chunk':
+        # Chunk-on-grid: no inputs.txt, no --merge-factor. The per-job
+        # slice is materialized at runtime by runmu2e. tbs.chunk_mode
+        # carries the source path + chunk size through jobpars.
+        job_args = []
         
     elif job_type == 'mixing':
         # Mixing jobs: add MaxEventsToSkip parameter to template

--- a/utils/prod_utils.py
+++ b/utils/prod_utils.py
@@ -547,10 +547,33 @@ def process_jobdef(jobdesc, fname, args):
     # Extract fields from JSON structure
     inloc = jobdesc_entry['inloc']
     tarball = jobdesc_entry['tarball']
-    
+
     # Copy jobdef to local directory if not already local
     if not Path(tarball).is_file():
         run(f"mdh copy-file -e 3 -o -v -s disk -l local {tarball}", shell=True, retries=3, retry_delay=60)
+
+    # If jobpars declares chunk_mode, materialize this job's slice before
+    # mu2e runs. runmu2e reads tbs.chunk_mode = {source, lines, local_filename}
+    # and writes the corresponding slice of the cvmfs source to local_filename
+    # in cwd. Every job's FCL references local_filename (set via
+    # fcl_overrides at jobdef-creation time), so mu2e reads whatever that
+    # file contains when it opens.
+    import shlex
+    jp_for_chunk = Mu2eJobPars(tarball)
+    tbs = jp_for_chunk.json_data.get('tbs', {}) if isinstance(jp_for_chunk.json_data, dict) else {}
+    chunk_mode = tbs.get('chunk_mode') if isinstance(tbs, dict) else None
+    if isinstance(chunk_mode, dict):
+        src = chunk_mode['source']
+        lines_per_chunk = int(chunk_mode['lines'])
+        local_name = chunk_mode['local_filename']
+        start = job_index_num * lines_per_chunk + 1
+        end = start + lines_per_chunk - 1
+        print(f"chunk_mode: extracting lines {start}-{end} of {src} -> {local_name}")
+        # Quote paths — they come from jobpars (cvmfs today, but future
+        # configs might contain whitespace or shell metacharacters).
+        sed_range = f"{start},{end}p"
+        cmd = f"sed -n {shlex.quote(sed_range)} {shlex.quote(src)} > {shlex.quote(local_name)}"
+        run(cmd, shell=True)
 
     # List input files
     job_io = Mu2eJobIO(tarball)
@@ -600,7 +623,7 @@ def process_jobdef(jobdesc, fname, args):
         raise
     
     outputs = jobdesc_entry['outputs']
-    return fcl, simjob_setup, infiles, outputs
+    return fcl, simjob_setup, infiles, outputs, inloc
 
 def push_output(output_specs, output_file="output.txt", parents_file="parents_list.txt", simjob_setup=None):
     """
@@ -642,19 +665,28 @@ def push_output(output_specs, output_file="output.txt", parents_file="parents_li
         print(f"Warning: pushOutput returned exit code {result}")
     return result
 
-def push_data(outputs, infiles, simjob_setup=None):
+def push_data(outputs, infiles, simjob_setup=None, track_parents=True):
     """Handle data file management and submission using wildcard patterns from JSON outputs.
-    
+
     Args:
         outputs: List of output specifications (dataset pattern, location)
         infiles: Space-separated list of input files (for parents_list.txt)
         simjob_setup: Path to SimJob setup script for art environment
+        track_parents: When True (default), writes parents_list.txt from
+            infiles and points output.txt at it. When False, writes
+            'none' in output.txt's third column and skips parents_list.txt
+            entirely — use for jobs whose inputs aren't SAM-registered
+            (e.g. cvmfs files via `inloc: dir:<path>`). printJson --parents
+            exits 25 on non-SAM parents, which cascades into
+            KeyError('checksum') inside pushOutput; this bool avoids that.
     """
     import glob
-    
-    # Write parents list
-    Path("parents_list.txt").write_text(infiles.replace(" ", "\n") + "\n")
-    
+
+    parents_field = "parents_list.txt" if track_parents else "none"
+
+    if track_parents:
+        Path("parents_list.txt").write_text(infiles.replace(" ", "\n") + "\n")
+
     # Build output specifications
     output_specs = []
     for output in outputs:
@@ -663,10 +695,10 @@ def push_data(outputs, infiles, simjob_setup=None):
         matching_files = glob.glob(dataset_pattern)
         print(f"Pattern '{dataset_pattern}' matched {len(matching_files)} files: {matching_files}")
         for filename in matching_files:
-            output_specs.append((location, filename, "parents_list.txt"))
-    
+            output_specs.append((location, filename, parents_field))
+
     # Use generic push function
-    return push_output(output_specs, "output.txt", "parents_list.txt", simjob_setup=simjob_setup)
+    return push_output(output_specs, "output.txt", parents_field, simjob_setup=simjob_setup)
 
 def push_logs(fcl, simjob_setup=None):
     """Handle log file management and submission.

--- a/utils/runmu2e.py
+++ b/utils/runmu2e.py
@@ -43,6 +43,7 @@ def main():
         sys.exit(1)
 
     # Process job based on mode
+    inloc = None  # populated by process_jobdef; None for template/direct_input
     if mode == 'template':
         fcl, simjob_setup = process_template(jobdesc[0], fname)
         infiles = fname
@@ -50,7 +51,13 @@ def main():
     elif mode == 'direct_input':
         fcl, simjob_setup, infiles, outputs = process_direct_input(jobdesc, fname, args)
     else:
-        fcl, simjob_setup, infiles, outputs = process_jobdef(jobdesc, fname, args)
+        fcl, simjob_setup, infiles, outputs, inloc = process_jobdef(jobdesc, fname, args)
+
+    # dir:<path> inloc means inputs are on a locally-mounted filesystem
+    # (typically cvmfs) and aren't SAM-registered — skip parent tracking
+    # on the push. All other cases (including None for template / direct
+    # input) default to tracking parents.
+    track_parents = not (isinstance(inloc, str) and inloc.startswith('dir:'))
     
     setup_cmd = f"source {simjob_setup}"
     mu2e_cmd = f"mu2e -c {fcl}"
@@ -76,7 +83,7 @@ def main():
     # Handle output files and submission (even if job failed)
     if not args.dry_run:
         if not job_failed:
-            push_data(outputs, infiles, simjob_setup=simjob_setup)
+            push_data(outputs, infiles, simjob_setup=simjob_setup, track_parents=track_parents)
         else:
             print("Job failed - skipping data file push, but uploading logs")
         # Always upload logs, even on failure

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -16,9 +16,11 @@
 ### Sources
 - [[pbi-sequence-workflow]] — how to use `json2jobdef` + `runmu2e` to produce `dts.mu2e.PBI*.art` outputs _(2026-04-21)_
 - [[input-data-dir-shape]] — use `inloc: "dir:<path>"` for cvmfs-resident inputs; basenames in input_data, runtime resolves via existing `dir:` prefix _(2026-04-21)_
+- [[input-data-chunk-mode]] — `chunk_lines` input_data shape; on-the-fly chunking at grid time via `tbs.chunk_mode` + runmu2e sed slice. Best of split_lines and dir: without the trade-offs _(2026-04-22)_
 
 ### Analyses
 <!-- entries added by wiki-query when answers are filed -->
 
 ### Maintenance
 - [[lint-2026-04-21]] — initial lint; wiki freshly initialized, 0 errors, 0 warnings, 1 info (coverage gap: no sources ingested yet) _(2026-04-21)_
+- [[lint-2026-04-22]] — post-PBI-sequence lint; 0 errors, 2 warnings (raw-slug ambiguity, stale overview questions), 3 info _(2026-04-22)_

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -42,6 +42,24 @@ Reason: three-part extension to support cvmfs-resident inputs without SAM or sta
 Reason: added auto-detection by absolute-path key in json2jobdef — `"input_data": {"/cvmfs/.../f.txt": 1}` is now the canonical literal shape. The explicit `{"literal": true}` form remains accepted for backward compat / clarity. Rule: a key starting with "/" triggers literal mode; SAM dataset names never start with "/" so the disambiguation is unambiguous. Mixing literal and non-literal keys in one input_data raises an explicit error.
 Source: in-session refactor 2026-04-21, verified with unit tests (160/160) and end-to-end run in /tmp/pbi_short.*
 
+## [2026-04-22] update | chunk_mode hardening (post-review)
+Reason: code review of the chunk_mode abstraction surfaced four issues. All addressed: (1) `sed` extraction in prod_utils.process_jobdef now uses shlex.quote for paths (cvmfs-safe today, but future configs could contain shell-unsafe chars); (2) json2jobdef._configure_chunk_mode rejects chunk_lines < 1 with a clear error; (3) PBISequence branch in jobdef.py now requires inputs OR chunk_mode — prevents submit-time misconfig from surfacing as fileNames:@nil at mu2e time; (4) new TestConfigureChunkMode class in test/test_unit.py, 9 tests. Also fixed defensive isinstance(chunk_mode, dict) check so pre-existing stash test's MagicMock mocking pattern doesn't trip the new code path. Unit suite now 181/181.
+Updated: input-data-chunk-mode.
+
+## [2026-04-22] ingest | chunk_mode (on-the-fly chunking at grid)
+Pages written: input-data-chunk-mode
+Pages updated: pbi-sequence-workflow (chunk_mode is now canonical; dir: + split_lines relegated to alternatives), index.md
+Reason: new input_data shape `{<cvmfs-path>: {"chunk_lines": N}}`. At submit, json2jobdef counts lines, sets njobs=ceil(lines/N), stores `tbs.chunk_mode={source,lines,local_filename}` in jobpars. At grid runtime, runmu2e reads chunk_mode, runs sed to extract the per-job slice to `chunk.txt`, mu2e reads it. No chunk staging, full N-way parallelism. Verified end-to-end locally: job index 5 extracted lines 5001-6000, produced dts.mu2e.PBINormal_33344.MDC2025ai.001430_00000005.art with 1000 events, art exit 0. Unit tests 172/172 pass. Implementation: json2jobdef._configure_chunk_mode helper + new 'chunk' job_type in determine_job_type (skip --inputs / --merge-factor), jobdef.py tbs pass-through, prod_utils.process_jobdef runtime sed extraction. PBISequence validation_rules relaxed: inputs+merge_factor now allowed not required. fname index gotcha documented: field [4] is job index (e.g. `etc.mu2e.index.000.0000005.txt` → index 5).
+Source: in-session implementation + test 2026-04-22 in /tmp/pbi_chunk_run.*
+
+## [2026-04-22] update | push_data API: `track_parents` bool instead of `inloc` string
+Reason: initial fix passed `inloc` kwarg through push_data and checked `inloc.startswith('dir:')` inside. Cleaner: push_data takes `track_parents: bool`; runmu2e computes the policy from inloc at the call site. Keeps push_data reusable and free of inloc-specific knowledge. 172/172 unit tests still pass. input-data-dir-shape updated to reflect the new API.
+Source: post-review refactor 2026-04-22
+
+## [2026-04-22] update | push_data handles dir: inloc parent tracking
+Reason: first real POMS grid run against iMDC2025-025 (v1.8.0 on cvmfs) succeeded in mu2e execution (25,438 events, art file produced) but pushOutput failed with `printJson --parents parents_list.txt <art> returned non-zero exit status 25` → `KeyError: 'checksum'` in pushOutput.copyFile. Root cause: for `inloc: dir:<path>` jobs, infiles are cvmfs paths that aren't SAM-registered; `printJson --parents` can't resolve them; metadata dict never gets 'checksum' populated. Fix: prod_utils.process_jobdef now returns inloc as 5th tuple element; push_data accepts inloc kwarg and writes `none` in output.txt third column (instead of `parents_list.txt`) when inloc starts with `dir:`. runmu2e updated to unpack and pass inloc through. Verified: 172/172 unit tests still pass. Wiki page input-data-dir-shape updated with a new "Output parent tracking" section.
+Source: in-session fix 2026-04-22 diagnosing grid job `27819857.0@jobsub05.fnal.gov` stderr
+
 ## [2026-04-21] update | pbi-sequence-workflow (production push via POMS map 025)
 Reason: first real --prod invocation landing in the production manager's poms_map/ directory. Pushed cnf.mu2e.PBINormal_33344.MDC2025ai.0.tar + cnf.mu2e.PBIPathological_33344.MDC2025ai.0.tar to /pnfs/mu2e/persistent/..., wrote /exp/mu2e/app/users/mu2epro/production_manager/poms_map/MDC2025-025.json (2-entry map), mkidxdef --prod created SAM index definition iMDC2025-025. POMS will discover iMDC2025-025 on its next scan and dispatch both PBI Normal + Pathological jobs using the dir:/cvmfs/.../DataFiles/PBI/ inloc. Also confirmed: --prod handles "already-exists" tarball gracefully (pushes without error when SAM already has that filename).
 Source: in-session --prod run 2026-04-21 in /tmp/mu2epro_run.*
@@ -60,3 +78,7 @@ Pages written: input-data-dir-shape
 Pages updated: pbi-sequence-workflow, index.md
 Reason: in review it became clear that jobfcl's pre-existing `dir:<path>` inloc already handles our case (cvmfs-resident inputs). The `literal` mode I added duplicated functionality without earning its keep — the only case it won (inputs from multiple distinct directories in one input_data) has no real use today. Removed: `inloc: "literal"` branch in jobfcl._locate_file, absolute-path detection in json2jobdef._create_inputs_file, `{"literal": true}` handling in calculate_merge_factor. Replaced: a small dispatch in json2jobdef that writes input_data keys verbatim when `inloc.startswith('dir:')`. Kept: the `source.runNumber` sequencer short-circuit in jobfcl (orthogonal fix, still needed for PBISequence). PBI config now uses `"inloc": "dir:/cvmfs/.../PBI/"` + basename keys. End-to-end verified: 25,438 events, exit 0, correct output filename. Unit tests 160/160 pass.
 Source: in-session revert 2026-04-21 in /tmp/pbi_dir.*
+
+## [2026-04-22] lint | 0 errors, 2 warnings, 3 info
+Report: [[lint-2026-04-22]]
+Fixed: (A) dropped two stale Open Questions from overview.md + refreshed Current Understanding to reflect chunk_mode as canonical; (C) added [[input-data-chunk-mode]] cross-link in input-data-dir-shape.md Related section. Deferred: (B) raw-slug ambiguity — left as convention debate; (D) index annotation — ADR entry still accurate for the decision recorded.

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -1,9 +1,8 @@
 ---
 title: Overview
 tags: [overview, synthesis]
-sources: []
-updated: 2026-04-21
 sources: [2026-04-21-pbi-sequence-implementation]
+updated: 2026-04-22
 ---
 
 # Mu2e prodtools — Operational Overview
@@ -13,9 +12,13 @@ sources: [2026-04-21-pbi-sequence-implementation]
 ## Current Understanding
 
 First substantial ingest is the 2026-04-21 PBI sequence work — a
-Python port of `gen_NoPrimaryPBISequence.sh` that required extending
-prodtools' jobdef mechanism with generic per-index linear overrides
-(`event_id_per_index`). Pattern worth noting: when a workflow
+Python port of `gen_NoPrimaryPBISequence.sh`. The initial approach
+extended prodtools' jobdef mechanism with generic per-index linear
+overrides (`event_id_per_index`). Subsequent iteration settled on
+`chunk_mode`: the submit-side shape is `"input_data": {<cvmfs-path>:
+{"chunk_lines": N}}`, and each grid worker `sed`-extracts its own
+slice from the cvmfs source at runtime — no staging of chunk files,
+full N-way parallelism. Pattern worth noting: when a workflow
 doesn't fit prodtools' existing abstractions, the fix is to extend
 the abstraction rather than bypass it — keeps `runmu2e` +
 `prod_utils.{run,push_data,push_logs}` as the single point of
@@ -23,16 +26,15 @@ maintenance for execution + SAM push.
 
 ## Open Questions
 
-- Does `jobfcl --index N` correctly render
-  `source.firstEventNumber = N × events_per_job` in the emitted FCL?
-  Code path is in place; verification deferred to first real chain
-  run.
-- Where should PBI chunk text files land for grid runs (stash vs
-  resilient)? Currently local-only.
+- Scale test of `chunk_mode` at N ≫ 52 jobs (first production run
+  used chunk_lines=1000 on a ~52,000-line source). Does sed on the
+  cvmfs source behave well when many workers hit it concurrently?
 
 ## Key Campaigns / Incidents / Decisions
 
 - [[2026-04-21-extend-jobdef-per-index-overrides]] — first
   substantive extension to prodtools' core jobdef mechanism.
 - [[pbi-sequence-workflow]] — PBI text-to-art pipeline, now
-  jobdef-native.
+  jobdef-native, canonical shape is chunk_mode.
+- [[input-data-chunk-mode]] — the canonical shape for parallel
+  consumption of large cvmfs-resident text files.

--- a/wiki/pages/input-data-chunk-mode.md
+++ b/wiki/pages/input-data-chunk-mode.md
@@ -1,0 +1,102 @@
+---
+title: On-the-fly chunking via chunk_lines (chunk_mode)
+tags: [reference, json2jobdef, runmu2e, jobdef]
+sources: [2026-04-21-pbi-sequence-implementation]
+updated: 2026-04-22
+---
+
+# On-the-fly chunking at grid (`chunk_mode`)
+
+Use when a single large text file on cvmfs needs to be processed in
+parallel by N grid jobs, each consuming a contiguous slice — without
+pre-splitting at submit time, without staging chunks into stash or
+resilient dCache. Each grid worker materializes its own slice from the
+cvmfs source when the job starts.
+
+Complements the other two shapes for cvmfs-resident inputs:
+
+|              | `dir:<path>` (single file → 1 job)          | `split_lines` (pre-split at submit)      | `chunk_mode` (on-the-fly at grid) |
+|---|---|---|---|
+| Pre-processing | none                                       | split + stage chunks to stash/resilient  | none                              |
+| njobs        | 1 per input file                            | `ceil(lines/split_lines)`                 | `ceil(lines/chunk_lines)`         |
+| Fan-out for downstream mixing | poor (1 art per file) | good (N arts per source file)             | good (N arts per source file)     |
+| Storage cost | 0 (cvmfs only)                              | N chunk files on stash/resilient          | 0 (cvmfs only; slices are ephemeral on grid workers) |
+
+`chunk_mode` is the sweet spot when the source is already on cvmfs and
+you want the N-way downstream fan-out without the chunk-staging
+pipeline.
+
+## JSON shape
+
+```json
+"input_data": {
+    "/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/PBI_Normal_33344.txt": {
+        "chunk_lines": 1000
+    }
+}
+```
+
+- Single absolute path as key; value is a dict with `chunk_lines: N`
+  where `N >= 1`. Invalid values raise at `json2jobdef` time.
+- For `PBISequence` source type specifically, the config must provide
+  either `inputs` + `merge_factor` (dir:-mode) or `chunk_mode` (this
+  path) — neither set raises at jobdef-creation time instead of
+  surfacing as a cryptic `fileNames: @nil` failure inside mu2e.
+- `json2jobdef` at submit time:
+  - counts lines in the source file, computes `njobs = ceil(lines/chunk_lines)`
+  - sets `config['chunk_mode'] = {source, lines, local_filename}` which flows into
+    `jobpars.json` → `tbs.chunk_mode`
+  - auto-injects `fcl_overrides["source.fileNames"] = ["chunk.txt"]` so every
+    job's FCL references the same local filename — contents differ per job
+    because each grid worker writes its own slice to that path
+  - does not create `inputs.txt`, `tbs.inputs` is unset
+
+## Grid runtime (runmu2e)
+
+On each grid worker, `utils/prod_utils.process_jobdef`:
+
+1. pulls the tarball (`mdh copy-file`)
+2. reads `tbs.chunk_mode` from jobpars
+3. computes `start = job_index_num * lines + 1`, `end = start + lines - 1`
+4. runs `sed -n "${start},${end}p" <source> > <local_filename>` — populates
+   the local chunk file with this job's slice
+5. invokes `jobfcl` → FCL points at local_filename, already set via
+   `fcl_overrides`
+6. runs `mu2e -c <fcl>` — mu2e reads the local chunk, produces its output
+
+Each job's output inherits the Mu2e-standard sequencer
+(`<run>_<index>` zero-padded) via `source.runNumber` in `event_id` and
+the existing `sequencer` short-circuit in `jobfcl`.
+
+## Verification (2026-04-22)
+
+End-to-end on PBI Normal:
+
+```
+fname=etc.mu2e.index.000.0000005.txt       (job index 5)
+Global job index: 5, Local job index within definition: 5
+chunk_mode: extracting lines 5001-6000 of /cvmfs/.../PBI_Normal_33344.txt -> chunk.txt
+outputs.PrimaryOutput.fileName: "dts.mu2e.PBINormal_33344.MDC2025ai.001430_00000005.art"
+TrigReport Events total = 1000 passed = 1000 failed = 0
+Art has completed and will exit with status 0
+```
+
+Chunk contents confirmed slice-correct: first line of chunk.txt is
+`85599067.99` (value at line 5001 of source), not `0` (which is line 1).
+
+## fname-index gotcha
+
+The grid convention for the index filename is
+`etc.mu2e.index.000.<NNNNNNN>.txt` — **field [4] (the 7-digit
+zero-padded sub-counter) is the job index**, not field [3] (the
+3-digit `000`). Production `mkidxdef` always emits field [3] as
+`000`. For local testing with a specific index, set
+`fname=etc.mu2e.index.000.0000<NNN>.txt`.
+
+## Related
+
+- [[pbi-sequence-workflow]] — canonical consumer
+- [[input-data-dir-shape]] — one-job-per-file alternative (no
+  parallelism)
+- `split_lines` (documented inline in pbi-sequence-workflow) —
+  pre-split + stage alternative

--- a/wiki/pages/input-data-dir-shape.md
+++ b/wiki/pages/input-data-dir-shape.md
@@ -28,6 +28,29 @@ relative to that directory.
 - `json2jobdef` detects `inloc.startswith('dir:')` and writes the keys
   to `inputs.txt` verbatim (no SAM lookup).
 
+## Output parent tracking
+
+For jobs consuming non-SAM inputs (cvmfs files under `dir:<path>`),
+`push_data` writes `none` in the third column of `output.txt`
+instead of pointing at a `parents_list.txt` file. `printJson --parents`
+can only resolve SAM-registered parents — if it gets a cvmfs path it
+exits 25, which cascades to `KeyError: 'checksum'` inside
+`pushOutput.copyFile` (metadata dict never populated).
+
+Implementation:
+
+- `prod_utils.process_jobdef` returns `inloc` as a 5th tuple element.
+- `prod_utils.push_data(..., track_parents: bool)` — when False, writes
+  `none` in `output.txt` and skips `parents_list.txt` entirely. `push_data`
+  itself is policy-free: the caller decides whether parents are
+  trackable.
+- `runmu2e` computes `track_parents = not inloc.startswith('dir:')` and
+  passes it to `push_data`. Other modes (`template`, `direct_input`)
+  default to `track_parents=True`.
+
+Verified by fixing a grid-job failure on 2026-04-22 where PBI outputs
+failed to register in SAM with the `KeyError: 'checksum'` cascade.
+
 ## Runtime path resolution
 
 `runmu2e` passes the jobdefs entry's `inloc` string to `jobfcl`. When
@@ -87,4 +110,6 @@ placeholders per-job.
 
 ## Related
 - [[pbi-sequence-workflow]] — primary consumer
+- [[input-data-chunk-mode]] — on-the-fly chunking alternative when
+  a single large text file should fan out to N parallel jobs
 - [[2026-04-21-fold-pbi-into-json2jobdef]] — the split_lines complement

--- a/wiki/pages/lint-2026-04-22.md
+++ b/wiki/pages/lint-2026-04-22.md
@@ -1,0 +1,91 @@
+---
+title: Lint Report 2026-04-22
+tags: [lint, maintenance]
+sources: []
+updated: 2026-04-22
+---
+
+# Lint Report — 2026-04-22
+
+## Summary
+- 🔴 Errors: 0
+- 🟡 Warnings: 2
+- 🔵 Info: 3
+
+## 🔴 Broken Links
+None. See Warnings for the `raw/` cross-reference ambiguity — treated
+as warning, not error, because the target file exists (just not under
+`pages/`).
+
+## 🔴 Missing Frontmatter
+None. All 6 pages under `wiki/pages/` have complete frontmatter
+(`title`, `tags`, `sources`, `updated`).
+
+## 🟡 Cross-references to `raw/` (schema ambiguity)
+
+Two pages use `[[2026-04-21-pbi-sequence-implementation]]` to point at
+a file that lives in `wiki/raw/`, not `wiki/pages/`:
+
+- [[2026-04-21-extend-jobdef-per-index-overrides]] line 95:
+  `Source: [[2026-04-21-pbi-sequence-implementation]] (ingested ...)`
+- [[pbi-sequence-workflow]] line 395:
+  `Source: [[2026-04-21-pbi-sequence-implementation]]`
+
+`wiki/SCHEMA.md` §Cross-References defines `[[slug]]` as
+`wiki/pages/<slug>.md` only. Strict reading → broken. Lenient /
+Obsidian reading → valid since the file exists somewhere in the vault.
+
+Recommendation: clarify in SCHEMA.md that `sources:` in frontmatter
+already covers the raw-file linkage, and body references to raw
+sources should use a plain relative path (e.g. `raw/2026-04-21-…md`)
+rather than the `[[…]]` wikilink syntax. Then edit the two body lines
+to drop the wikilink wrapping.
+
+## 🟡 Stale claims in `overview.md`
+
+Two Open Questions in `overview.md` have been answered by subsequent
+work but the page was not refreshed:
+
+- Q1: "Does `jobfcl --index N` correctly render
+  `source.firstEventNumber = N × events_per_job` in the emitted FCL?"
+  — Answered yes by 2026-04-21 end-to-end test (25,438 events, exit
+  0); superseded anyway by the chunk_mode path which doesn't use
+  `firstEventNumber`.
+- Q2: "Where should PBI chunk text files land for grid runs (stash
+  vs resilient)?"
+  — Obviated by [[input-data-chunk-mode]]: chunks never materialize
+  on shared storage; each grid worker `sed`-extracts its own slice.
+
+Fix: delete both bullets from `overview.md`, and bump the `updated:`
+stamp. Optionally replace with a new open question (e.g. "scale test
+of chunk_mode at N≫52 jobs").
+
+## 🔵 Orphan pages
+- [[lint-2026-04-21]] — no inbound page-level references (only
+  referenced from `index.md` under Maintenance, which is expected for
+  dated lint reports). Acceptable as Info.
+- [[lint-2026-04-22]] (this file) — likewise expected.
+
+## 🔵 Index freshness
+
+`index.md` under Decisions still says
+`[[2026-04-21-fold-pbi-into-json2jobdef]] — ... add a split_lines
+input_data shape to json2jobdef`. The ADR itself is correctly
+scoped to split_lines (the approach at the time), but `split_lines`
+is now superseded by `chunk_lines` per [[input-data-chunk-mode]]. The
+index entry is technically accurate about the decision content; a
+reader arriving via the index might expect the current canonical path
+to be mentioned. Optional: append a parenthetical like `(superseded
+by chunk_lines — see [[input-data-chunk-mode]])`.
+
+## 🔵 Missing cross-references
+- [[input-data-dir-shape]] and [[input-data-chunk-mode]] are mutual
+  alternatives; chunk-mode links to dir-shape ✓, but dir-shape does
+  not link to chunk-mode. Symmetric link would help the reader
+  choosing between the two. One-line add in the Related section of
+  `input-data-dir-shape.md`.
+
+## 🔵 Coverage gaps
+None pressing. The canonical workflow page ([[pbi-sequence-workflow]])
+is well cross-referenced. Campaigns / Incidents / Runs index
+sections are empty — expected at this early stage.

--- a/wiki/pages/pbi-sequence-workflow.md
+++ b/wiki/pages/pbi-sequence-workflow.md
@@ -21,13 +21,13 @@ Text files on cvmfs:
 Each ~25,439 lines. Frozen since Oct 2021. DocDB 33344 is the only
 PBI set currently.
 
-## JSON config shape — current default: `dir:` inloc (one job, no split)
+## JSON config shape — current default: `chunk_mode` (N jobs, on-the-fly)
 
-CVMFS is already grid-readable, and our PBI source file is on cvmfs.
-The canonical path is to read it directly, no splitting, no staging —
-by pointing `inloc` at the containing directory (see
-[[input-data-dir-shape]]). One job, ~50s wallclock, one art file with
-all 25,438 events.
+The PBI source file on cvmfs is already grid-readable. The canonical
+path is `chunk_lines` (see [[input-data-chunk-mode]]) — each grid
+worker extracts its own slice from cvmfs at job start. No
+pre-splitting, no staging, N-way parallelism for downstream mixing
+fan-out.
 
 ```json
 {
@@ -35,11 +35,13 @@ all 25,438 events.
   "dsconf": "MDC2025ai",
   "fcl": "Production/JobConfig/primary/NoPrimaryPBISequence.fcl",
   "input_data": {
-    "PBI_Normal_33344.txt": 1
+    "/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/PBI_Normal_33344.txt": {
+      "chunk_lines": 1000
+    }
   },
   "run": 1430,
   "owner": "mu2e",
-  "inloc": "dir:/cvmfs/mu2e.opensciencegrid.org/DataFiles/PBI/",
+  "inloc": "none",
   "outloc": {"*.art": "tape"},
   "simjob_setup": "/cvmfs/mu2e.opensciencegrid.org/Musings/SimJob/MDC2025ai/setup.sh",
   "fcl_overrides": {
@@ -49,11 +51,29 @@ all 25,438 events.
 }
 ```
 
-`json2jobdef` sees `inloc.startswith('dir:')` and writes the basename
-keys to `inputs.txt` verbatim. At runtime, `jobfcl` prepends the
-directory prefix (existing `dir:` behavior — no new mechanism).
+Produces 26 jobs per entry (25,438 lines / 1000 per chunk). Each job
+processes 1000 events from its own slice of the source file.
 
-### Alternative: split_lines (many jobs, local chunks)
+**Submit-time effect:**
+- `njobs: 26` in the jobdefs_list entry
+- `tbs.chunk_mode = {source, lines, local_filename: "chunk.txt"}` in
+  jobpars
+- `fcl_overrides["source.fileNames"] = ["chunk.txt"]` auto-injected
+  so every job's FCL references the local slice
+- No `inputs.txt`, no `tbs.inputs`
+
+**Grid-time effect per job:** `runmu2e` sees `tbs.chunk_mode`, runs
+`sed -n "start,end p" <cvmfs-source> > chunk.txt`, FCL points at
+`chunk.txt`, mu2e reads the slice.
+
+### Alternative: `dir:<path>` inloc (one job, no chunking)
+
+If you want a single job reading the entire file (~50s wall clock),
+see [[input-data-dir-shape]]. Less parallelism, but simpler tbs shape.
+
+### Alternative: `split_lines` (pre-split at submit)
+
+### Alternative: `split_lines` (many jobs, pre-split at submit, chunks on stash)
 
 If you need a SAM dataset of many PBI art files (e.g. for mixing
 parallelism over the dataset), use the `split_lines` shape instead:


### PR DESCRIPTION
json2jobdef: new input_data shape {<cvmfs-path>: {"chunk_lines": N}} counts lines and sets njobs at submit time; stores tbs.chunk_mode so each grid worker sed-extracts its own slice from the cvmfs source at runtime — full N-way parallelism with zero chunk staging.

prod_utils: runtime chunk extraction with shlex-quoted sed; file:// protocol for dir: inloc; push_data takes track_parents:bool so dir: parents (not SAM-registered) don't fail pushOutput's printJson --parents.

jobdef: PBISequence source type now requires either inputs+merge_factor or chunk_mode at jobdef time, preventing the cryptic fileNames:@nil failure that would otherwise surface inside mu2e.

Tests: 21 new tests (181 total) covering chunk_mode configuration, source.runNumber sequencing, and event_id_per_index evaluation.

Wiki: chunk_mode documented as canonical PBI shape; input-data- chunk-mode page added; overview refreshed with scale-test open question; lint-2026-04-22 filed.