### PR TITLE
g4bl runner: mdh copy-file fetch for basename-only tarballs on grid

### DIFF
--- a/utils/prod_utils.py
+++ b/utils/prod_utils.py
@@ -627,7 +627,15 @@ def process_g4bl_jobdef(jobdesc_entry, fname, args):
     tarball = jobdesc_entry.get('tarball')
     if tarball:
         if not Path(tarball).is_file():
-            raise RuntimeError(f"tarball not found: {tarball}")
+            # On grid workers the tarball arrives only as a basename in the
+            # POMS map. Use `mdh copy-file` to fetch from dCache to cwd —
+            # same pattern as art-side process_direct_input. cnf tarballs
+            # live on `disk` location (active workflow access) by Mu2e
+            # convention; matches art-side `-s disk` for cnf.*.tar.
+            run(f"mdh copy-file -e 3 -o -v -s disk -l local {tarball}",
+                shell=True, retries=3, retry_delay=60)
+            if not Path(tarball).is_file():
+                raise RuntimeError(f"mdh copy-file did not produce {tarball} in cwd")
         extract_dir = tempfile.mkdtemp(prefix='g4bl_extract_')
         with tarfile.open(tarball) as t:
             t.extractall(extract_dir)


### PR DESCRIPTION
On grid workers the POMS map's `tarball` field is a basename only — Condor doesn't auto-stage cnf.*.tar (only the map JSON via dropbox). The previous code raised "tarball not found" immediately. Now mirrors the art-side `process_direct_input:411` pattern: if the basename isn't local, run `mdh copy-file -e 3 -o -v -s disk -l local <tarball>` to fetch from dCache. cnf tarballs live on `disk` by Mu2e convention (matching art-side `-s disk` and pushOutput `disk` location for the G4blPOT TESTaa demonstrator tarball at /pnfs/mu2e/persistent/datasets/ phy-etc/cnf/mu2e/G4blPOT/TESTaa/tar/c7/74/).

Both smoke modes verified: full-path local (regression) and basename-only worker simulation.

Required for grid execution; pending cvmfs prodtools release with this commit.