### PR TITLE
docs: trim latest-datasets to just the dataset names

### DIFF
--- a/docs/latest_datasets.md
+++ b/docs/latest_datasets.md
@@ -1,307 +1,185 @@
 # Latest MDC2025 datasets
 
-Latest dsconf per description across the three main tiers. Generated 2026-08-06.
+Latest dsconf per description. Generated 2026-08-06.
+Excludes `Triggered` variants and the superseded `MDC2025-NNN` series.
 
-| tier | descriptions | pattern |
-|---|---:|---|
-| dig | 51 | `dig.mu2e.%.MDC2025%best%.art` |
-| mcs | 63 | `mcs.mu2e.%.MDC2025%best%.art` |
-| nts | 46 | `nts.mu2e.%.MDC2025%best%.root` |
+## dig (51)
 
-## Scope and method
-
-Two exclusions, both deliberate:
-
-- **`Triggered` variants** — filtered with `grep -v Trig`.
-- **The `MDC2025-NNN` ntuple series** — superseded, excluded via the
-  `%best%` term, which no `MDC2025-NNN` dsconf contains. This drops 16
-  `nts` descriptions, all of them `*-reco-ntuple`, `ensembleMDS3c`, or
-  `ensembleMDS3cNtuple`. Verified it changes no winner: of the 46
-  descriptions present either way, every one keeps the same latest
-  dsconf.
-
-All three tiers use the default `--latest-by dsconf` (lexicographic).
-That is correct here **because** `MDC2025-NNN` is excluded — with both
-series in play, `MDC2025-002` sorts below `MDC2025au_best_v1_5` (`-` is
-0x2D, `a` is 0x61) and dsconf order returns stale rows. If you ever
-re-include that series, switch to `--latest-by time`.
-
-**versions** is the `--show-count` column: how many dsconf versions exist
-for the description, the listed one being newest. `1` = produced once and
-never revised. `--superseded` prints the older versions themselves.
-
----
-
-# dig
-
-```bash
-python3 bin/latestDatasets --defname 'dig.mu2e.%.MDC2025%best%.art' --show-count | grep -v Trig
+```
+dig.mu2e.CeEndpointOnSpill.MDC2025an_best_v1_1.art
+dig.mu2e.CeMLeadingLogMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.CeMLeadingLogOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.CePLeadingLogMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.CePLeadingLogOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.CePlusEndpointOnSpill.MDC2025an_best_v1_1.art
+dig.mu2e.CosmicCRYAllOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.CosmicCRYExtracted.MDC2025au_best_v1_5.art
+dig.mu2e.CosmicCalibOnSpill.MDC2025ap_best_v1_1.art
+dig.mu2e.CosmicSignalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.CosmicSignalOffSpill.MDC2025an_best_v1_1.art
+dig.mu2e.CosmicSignalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.DIOtail95Mix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.DIOtail95OnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.FlatGammaCaloMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.FlatGammaCaloOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.FlatGammaMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.FlatGammaOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.FlatMuMinusOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.FlateMinusMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.FlateMinusOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.FlatePlusMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.FlatePlusOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.IPAMuminusMichelMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.IPAMuminusMichelOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.MuCap1809keVCaloMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.MuCap1809keVCaloOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.NoPrimaryMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.PBINormal_33344Mix1BB.MDC2025ai_best_v1_3.art
+dig.mu2e.PBIPathological_33344Mix1BB.MDC2025ai_best_v1_3.art
+dig.mu2e.PbarResamplingMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.PbarResamplingOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RMCExternalOnSpill.MDC2025an_best_v1_1.art
+dig.mu2e.RMCInternalOnSpill.MDC2025an_best_v1_1.art
+dig.mu2e.RMCPhaseSpace0NExternalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.RMCPhaseSpace0NExternalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RMCPhaseSpace0NInternalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.RMCPhaseSpace0NInternalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RMCPhaseSpace1NExternalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.RMCPhaseSpace1NExternalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RMCPhaseSpace1NInternalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.RMCPhaseSpace1NInternalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RPCExternalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RPCExternalPhysicalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.RPCExternalPhysicalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.RPCInternalOnSpill.MDC2025ap_best_v1_1.art
+dig.mu2e.RPCInternalPhysicalMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.RPCInternalPhysicalOnSpill.MDC2025au_best_v1_5.art
+dig.mu2e.ensembleMDS3bOnSpill.MDC2025au_best_v1_1.art
+dig.mu2e.ensembleMDS3cMix1BB.MDC2025au_best_v1_3.art
+dig.mu2e.ensembleMDS3cOnSpill.MDC2025au_best_v1_5.art
 ```
 
-### Campaign spread
+<sub>refresh: <code>python3 bin/latestDatasets --defname 'dig.mu2e.%.MDC2025%best%.art' | grep -v Trig</code></sub>
 
-| dsconf | datasets |
-|---|---:|
-| `MDC2025au_best_v1_5` | 22 |
-| `MDC2025au_best_v1_3` | 19 |
-| `MDC2025an_best_v1_1` | 5 |
-| `MDC2025ai_best_v1_3` | 2 |
-| `MDC2025ap_best_v1_1` | 2 |
-| `MDC2025au_best_v1_1` | 1 |
+## mcs (63)
 
-### Datasets (51)
-
-| description | dsconf | versions |
-|---|---|---:|
-| CeEndpointOnSpill | `MDC2025an_best_v1_1` | 1 |
-| CeMLeadingLogMix1BB | `MDC2025au_best_v1_3` | 2 |
-| CeMLeadingLogOnSpill | `MDC2025au_best_v1_5` | 3 |
-| CePLeadingLogMix1BB | `MDC2025au_best_v1_3` | 2 |
-| CePLeadingLogOnSpill | `MDC2025au_best_v1_5` | 3 |
-| CePlusEndpointOnSpill | `MDC2025an_best_v1_1` | 1 |
-| CosmicCRYAllOnSpill | `MDC2025au_best_v1_5` | 2 |
-| CosmicCRYExtracted | `MDC2025au_best_v1_5` | 2 |
-| CosmicCalibOnSpill | `MDC2025ap_best_v1_1` | 1 |
-| CosmicSignalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| CosmicSignalOffSpill | `MDC2025an_best_v1_1` | 1 |
-| CosmicSignalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| DIOtail95Mix1BB | `MDC2025au_best_v1_3` | 2 |
-| DIOtail95OnSpill | `MDC2025au_best_v1_5` | 3 |
-| FlatGammaCaloMix1BB | `MDC2025au_best_v1_3` | 3 |
-| FlatGammaCaloOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatGammaMix1BB | `MDC2025au_best_v1_3` | 3 |
-| FlatGammaOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatMuMinusOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlateMinusMix1BB | `MDC2025au_best_v1_3` | 2 |
-| FlateMinusOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatePlusMix1BB | `MDC2025au_best_v1_3` | 2 |
-| FlatePlusOnSpill | `MDC2025au_best_v1_5` | 2 |
-| IPAMuminusMichelMix1BB | `MDC2025au_best_v1_3` | 2 |
-| IPAMuminusMichelOnSpill | `MDC2025au_best_v1_5` | 3 |
-| MuCap1809keVCaloMix1BB | `MDC2025au_best_v1_3` | 2 |
-| MuCap1809keVCaloOnSpill | `MDC2025au_best_v1_5` | 2 |
-| NoPrimaryMix1BB | `MDC2025au_best_v1_3` | 2 |
-| PBINormal_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| PBIPathological_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| PbarResamplingMix1BB | `MDC2025au_best_v1_3` | 2 |
-| PbarResamplingOnSpill | `MDC2025au_best_v1_5` | 3 |
-| RMCExternalOnSpill | `MDC2025an_best_v1_1` | 1 |
-| RMCInternalOnSpill | `MDC2025an_best_v1_1` | 1 |
-| RMCPhaseSpace0NExternalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| RMCPhaseSpace0NExternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace0NInternalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| RMCPhaseSpace0NInternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace1NExternalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| RMCPhaseSpace1NExternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace1NInternalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| RMCPhaseSpace1NInternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RPCExternalOnSpill | `MDC2025au_best_v1_5` | 2 |
-| RPCExternalPhysicalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| RPCExternalPhysicalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| RPCInternalOnSpill | `MDC2025ap_best_v1_1` | 1 |
-| RPCInternalPhysicalMix1BB | `MDC2025au_best_v1_3` | 2 |
-| RPCInternalPhysicalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| ensembleMDS3bOnSpill | `MDC2025au_best_v1_1` | 1 |
-| ensembleMDS3cMix1BB | `MDC2025au_best_v1_3` | 3 |
-| ensembleMDS3cOnSpill | `MDC2025au_best_v1_5` | 2 |
-
-### Not at MDC2025au (9)
-
-| description | latest dsconf | versions |
-|---|---|---:|
-| CeEndpointOnSpill | `MDC2025an_best_v1_1` | 1 |
-| CePlusEndpointOnSpill | `MDC2025an_best_v1_1` | 1 |
-| CosmicCalibOnSpill | `MDC2025ap_best_v1_1` | 1 |
-| CosmicSignalOffSpill | `MDC2025an_best_v1_1` | 1 |
-| PBINormal_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| PBIPathological_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| RMCExternalOnSpill | `MDC2025an_best_v1_1` | 1 |
-| RMCInternalOnSpill | `MDC2025an_best_v1_1` | 1 |
-| RPCInternalOnSpill | `MDC2025ap_best_v1_1` | 1 |
-
----
-
-# mcs
-
-```bash
-python3 bin/latestDatasets --defname 'mcs.mu2e.%.MDC2025%best%.art' --show-count | grep -v Trig
+```
+mcs.mu2e.CeEndpointOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CeMLeadingLogMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.CeMLeadingLogOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CeMLeadingLogOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.CePLeadingLogMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.CePLeadingLogOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CePLeadingLogOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.CePlusEndpointOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CosmicCRYAllOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.CosmicCRYExtracted.MDC2025au_best_v1_5.art
+mcs.mu2e.CosmicCalibOnSpill.MDC2025ar_best_v1_1.art
+mcs.mu2e.CosmicSignalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.CosmicSignalOffSpill-CH-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CosmicSignalOffSpill-CH.MDC2025ar_best_v1_1.art
+mcs.mu2e.CosmicSignalOffSpill-LH-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CosmicSignalOffSpill-LH.MDC2025ar_best_v1_1.art
+mcs.mu2e.CosmicSignalOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.CosmicSignalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.DIOtail95Mix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.DIOtail95OnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.DIOtail95OnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.FlatGammaCaloMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.FlatGammaCaloOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.FlatGammaMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.FlatGammaOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.FlatMuMinusOnSpill-reco.MDC2025aq_best_v1_1.art
+mcs.mu2e.FlatMuMinusOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.FlateMinusMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.FlateMinusOnSpill-reco.MDC2025aq_best_v1_1.art
+mcs.mu2e.FlateMinusOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.FlatePlusMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.FlatePlusOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.IPAMuminusMichelMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.IPAMuminusMichelOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.IPAMuminusMichelOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.MuCap1809keVCaloMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.MuCap1809keVCaloOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.NoPrimaryMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.PBINormal_33344Mix1BB.MDC2025ai_best_v1_3.art
+mcs.mu2e.PBIPathological_33344Mix1BB.MDC2025ai_best_v1_3.art
+mcs.mu2e.PbarResamplingMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.PbarResamplingOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RMCExternalOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.RMCExternalOnSpill.MDC2025ar_best_v1_1.art
+mcs.mu2e.RMCInternalOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.RMCInternalOnSpill.MDC2025ar_best_v1_1.art
+mcs.mu2e.RMCPhaseSpace0NExternalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.RMCPhaseSpace0NExternalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RMCPhaseSpace0NInternalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.RMCPhaseSpace0NInternalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RMCPhaseSpace1NExternalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.RMCPhaseSpace1NExternalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RMCPhaseSpace1NInternalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.RMCPhaseSpace1NInternalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RPCExternalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RPCExternalPhysicalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.RPCExternalPhysicalOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.RPCExternalPhysicalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.RPCInternalPhysicalMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.RPCInternalPhysicalOnSpill-reco.MDC2025an_best_v1_1.art
+mcs.mu2e.RPCInternalPhysicalOnSpill.MDC2025au_best_v1_5.art
+mcs.mu2e.ensembleMDS3cMix1BB.MDC2025au_best_v1_1.art
+mcs.mu2e.ensembleMDS3cOnSpill.MDC2025au_best_v1_5.art
 ```
 
-### Campaign spread
+<sub>refresh: <code>python3 bin/latestDatasets --defname 'mcs.mu2e.%.MDC2025%best%.art' | grep -v Trig</code></sub>
 
-| dsconf | datasets |
-|---|---:|
-| `MDC2025au_best_v1_5` | 22 |
-| `MDC2025au_best_v1_1` | 19 |
-| `MDC2025an_best_v1_1` | 13 |
-| `MDC2025ar_best_v1_1` | 5 |
-| `MDC2025ai_best_v1_3` | 2 |
-| `MDC2025aq_best_v1_1` | 2 |
+## nts (46)
 
-### Datasets (48)
-
-| description | dsconf | versions |
-|---|---|---:|
-| CeMLeadingLogMix1BB | `MDC2025au_best_v1_1` | 2 |
-| CeMLeadingLogOnSpill | `MDC2025au_best_v1_5` | 3 |
-| CePLeadingLogMix1BB | `MDC2025au_best_v1_1` | 2 |
-| CePLeadingLogOnSpill | `MDC2025au_best_v1_5` | 4 |
-| CosmicCRYAllOnSpill | `MDC2025au_best_v1_5` | 3 |
-| CosmicCRYExtracted | `MDC2025au_best_v1_5` | 3 |
-| CosmicCalibOnSpill | `MDC2025ar_best_v1_1` | 2 |
-| CosmicSignalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| CosmicSignalOffSpill-CH | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOffSpill-LH | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| DIOtail95Mix1BB | `MDC2025au_best_v1_1` | 2 |
-| DIOtail95OnSpill | `MDC2025au_best_v1_5` | 3 |
-| FlatGammaCaloMix1BB | `MDC2025au_best_v1_1` | 3 |
-| FlatGammaCaloOnSpill | `MDC2025au_best_v1_5` | 3 |
-| FlatGammaMix1BB | `MDC2025au_best_v1_1` | 3 |
-| FlatGammaOnSpill | `MDC2025au_best_v1_5` | 3 |
-| FlatMuMinusOnSpill | `MDC2025au_best_v1_5` | 3 |
-| FlateMinusMix1BB | `MDC2025au_best_v1_1` | 2 |
-| FlateMinusOnSpill | `MDC2025au_best_v1_5` | 3 |
-| FlatePlusMix1BB | `MDC2025au_best_v1_1` | 2 |
-| FlatePlusOnSpill | `MDC2025au_best_v1_5` | 3 |
-| IPAMuminusMichelMix1BB | `MDC2025au_best_v1_1` | 2 |
-| IPAMuminusMichelOnSpill | `MDC2025au_best_v1_5` | 3 |
-| MuCap1809keVCaloMix1BB | `MDC2025au_best_v1_1` | 2 |
-| MuCap1809keVCaloOnSpill | `MDC2025au_best_v1_5` | 2 |
-| NoPrimaryMix1BB | `MDC2025au_best_v1_1` | 2 |
-| PBINormal_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| PBIPathological_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| PbarResamplingMix1BB | `MDC2025au_best_v1_1` | 2 |
-| PbarResamplingOnSpill | `MDC2025au_best_v1_5` | 2 |
-| RMCExternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| RMCInternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| RMCPhaseSpace0NExternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace0NExternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace0NInternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace0NInternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace1NExternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace1NExternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace1NInternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace1NInternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RPCExternalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| RPCExternalPhysicalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RPCExternalPhysicalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| RPCInternalPhysicalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RPCInternalPhysicalOnSpill | `MDC2025au_best_v1_5` | 3 |
-| ensembleMDS3cMix1BB | `MDC2025au_best_v1_1` | 3 |
-| ensembleMDS3cOnSpill | `MDC2025au_best_v1_5` | 3 |
-
-### `-reco` suffixed descriptions (15)
-
-The `-reco` suffix is in the DESCRIPTION, not just the cnf name —
-output of the generic chained cnfs, a parallel naming line for the
-same physics. Separated so they do not read as the latest version
-of the unsuffixed dataset.
-
-| description | dsconf | versions |
-|---|---|---:|
-| CeEndpointOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| CeMLeadingLogOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| CePLeadingLogOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| CePlusEndpointOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| CosmicSignalOffSpill-CH-reco | `MDC2025an_best_v1_1` | 1 |
-| CosmicSignalOffSpill-LH-reco | `MDC2025an_best_v1_1` | 1 |
-| CosmicSignalOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| DIOtail95OnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| FlatMuMinusOnSpill-reco | `MDC2025aq_best_v1_1` | 1 |
-| FlateMinusOnSpill-reco | `MDC2025aq_best_v1_1` | 1 |
-| IPAMuminusMichelOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| RMCExternalOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| RMCInternalOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| RPCExternalPhysicalOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-| RPCInternalPhysicalOnSpill-reco | `MDC2025an_best_v1_1` | 1 |
-
-### Not at MDC2025au (7)
-
-| description | latest dsconf | versions |
-|---|---|---:|
-| CosmicCalibOnSpill | `MDC2025ar_best_v1_1` | 2 |
-| CosmicSignalOffSpill-CH | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOffSpill-LH | `MDC2025ar_best_v1_1` | 1 |
-| PBINormal_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| PBIPathological_33344Mix1BB | `MDC2025ai_best_v1_3` | 1 |
-| RMCExternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| RMCInternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-
----
-
-# nts
-
-```bash
-python3 bin/latestDatasets --defname 'nts.mu2e.%.MDC2025%best%.root' --show-count | grep -v Trig
+```
+nts.mu2e.CeMLeadingLogMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.CeMLeadingLogOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.CePLeadingLogMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.CePLeadingLogOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.CosmicCRYAllOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.CosmicCRYExtracted.MDC2025ar_best_v1_1.root
+nts.mu2e.CosmicCalibOnSpill.MDC2025ar_best_v1_1.root
+nts.mu2e.CosmicSignalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.CosmicSignalOffSpill-CH.MDC2025ar_best_v1_1.root
+nts.mu2e.CosmicSignalOffSpill-LH.MDC2025ar_best_v1_1.root
+nts.mu2e.CosmicSignalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.DIOtail95Mix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.DIOtail95OnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.FlatGammaCaloMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.FlatGammaCaloOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.FlatGammaMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.FlatGammaOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.FlatMuMinusOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.FlateMinusMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.FlateMinusOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.FlatePlusMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.FlatePlusOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.IPAMuminusMichelMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.IPAMuminusMichelOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.MuCap1809keVCaloMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.MuCap1809keVCaloOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.NoPrimaryMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.PbarResamplingMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.PbarResamplingOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RMCExternalOnSpill.MDC2025ar_best_v1_1.root
+nts.mu2e.RMCInternalOnSpill.MDC2025ar_best_v1_1.root
+nts.mu2e.RMCPhaseSpace0NExternalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.RMCPhaseSpace0NExternalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RMCPhaseSpace0NInternalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.RMCPhaseSpace0NInternalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RMCPhaseSpace1NExternalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.RMCPhaseSpace1NExternalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RMCPhaseSpace1NInternalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.RMCPhaseSpace1NInternalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RPCExternalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RPCExternalPhysicalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.RPCExternalPhysicalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.RPCInternalPhysicalMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.RPCInternalPhysicalOnSpill.MDC2025au_best_v1_5.root
+nts.mu2e.ensembleMDS3cMix1BB.MDC2025au_best_v1_1.root
+nts.mu2e.ensembleMDS3cOnSpill.MDC2025au_best_v1_5.root
 ```
 
-### Campaign spread
-
-| dsconf | datasets |
-|---|---:|
-| `MDC2025au_best_v1_5` | 21 |
-| `MDC2025au_best_v1_1` | 19 |
-| `MDC2025ar_best_v1_1` | 6 |
-
-### Datasets (46)
-
-| description | dsconf | versions |
-|---|---|---:|
-| CeMLeadingLogMix1BB | `MDC2025au_best_v1_1` | 2 |
-| CeMLeadingLogOnSpill | `MDC2025au_best_v1_5` | 2 |
-| CePLeadingLogMix1BB | `MDC2025au_best_v1_1` | 2 |
-| CePLeadingLogOnSpill | `MDC2025au_best_v1_5` | 2 |
-| CosmicCRYAllOnSpill | `MDC2025au_best_v1_5` | 2 |
-| CosmicCRYExtracted | `MDC2025ar_best_v1_1` | 1 |
-| CosmicCalibOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| CosmicSignalOffSpill-CH | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOffSpill-LH | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOnSpill | `MDC2025au_best_v1_5` | 2 |
-| DIOtail95Mix1BB | `MDC2025au_best_v1_1` | 2 |
-| DIOtail95OnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatGammaCaloMix1BB | `MDC2025au_best_v1_1` | 2 |
-| FlatGammaCaloOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatGammaMix1BB | `MDC2025au_best_v1_1` | 2 |
-| FlatGammaOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatMuMinusOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlateMinusMix1BB | `MDC2025au_best_v1_1` | 2 |
-| FlateMinusOnSpill | `MDC2025au_best_v1_5` | 2 |
-| FlatePlusMix1BB | `MDC2025au_best_v1_1` | 2 |
-| FlatePlusOnSpill | `MDC2025au_best_v1_5` | 2 |
-| IPAMuminusMichelMix1BB | `MDC2025au_best_v1_1` | 2 |
-| IPAMuminusMichelOnSpill | `MDC2025au_best_v1_5` | 2 |
-| MuCap1809keVCaloMix1BB | `MDC2025au_best_v1_1` | 2 |
-| MuCap1809keVCaloOnSpill | `MDC2025au_best_v1_5` | 2 |
-| NoPrimaryMix1BB | `MDC2025au_best_v1_1` | 2 |
-| PbarResamplingMix1BB | `MDC2025au_best_v1_1` | 1 |
-| PbarResamplingOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCExternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| RMCInternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| RMCPhaseSpace0NExternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace0NExternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace0NInternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace0NInternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace1NExternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace1NExternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RMCPhaseSpace1NInternalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RMCPhaseSpace1NInternalOnSpill | `MDC2025au_best_v1_5` | 1 |
-| RPCExternalOnSpill | `MDC2025au_best_v1_5` | 2 |
-| RPCExternalPhysicalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RPCExternalPhysicalOnSpill | `MDC2025au_best_v1_5` | 2 |
-| RPCInternalPhysicalMix1BB | `MDC2025au_best_v1_1` | 2 |
-| RPCInternalPhysicalOnSpill | `MDC2025au_best_v1_5` | 2 |
-| ensembleMDS3cMix1BB | `MDC2025au_best_v1_1` | 2 |
-| ensembleMDS3cOnSpill | `MDC2025au_best_v1_5` | 2 |
-
-### Not at MDC2025au (6)
-
-| description | latest dsconf | versions |
-|---|---|---:|
-| CosmicCRYExtracted | `MDC2025ar_best_v1_1` | 1 |
-| CosmicCalibOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOffSpill-CH | `MDC2025ar_best_v1_1` | 1 |
-| CosmicSignalOffSpill-LH | `MDC2025ar_best_v1_1` | 1 |
-| RMCExternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
-| RMCInternalOnSpill | `MDC2025ar_best_v1_1` | 1 |
+<sub>refresh: <code>python3 bin/latestDatasets --defname 'nts.mu2e.%.MDC2025%best%.root' | grep -v Trig</code></sub>


### PR DESCRIPTION
- **Clean up unused version_info variable in runfcl.py**
- **Major prodtools enhancements: famtree, logparser, and runjobdef improvements**
- **Simplify famtree: use forest theme, clean styling, remove unused code**
- **Add SimJob setup validation to json2jobdef and fix cleanup behavior**
- **Fix auxiliary file selection bug in runjobdef**
- **Add genFilterEff tool and enhance famtree with efficiency stats**
- **Add timestamps to run function in prod_utils**
- **Simplify fcldump to use existing datasetFileList command**
- **Use direct Python function calls instead of subprocess**
- **Refactor main() to use get_dataset_files() - eliminate code duplication**
- **Remove unnecessary try/except blocks in get_dataset_files()**
- **Use server-side filtering for SAM definition queries**
- **Remove unnecessary try/except blocks in datasetFileList main()**
- **Detect individual file locations from SAMWeb for mdh copy**
- **Simplify samweb_wrapper import handling**
- **Enhance logparser with CSV export and job timestamp extraction**
- **Update job configurations and POMS settings**
- **Add POMS map analyzer utility**
- **Fix fcldump jobdef matching to use exact field match**
- **Refactor utilities for better code quality and location handling**
- **Add new utilities for dataset monitoring and log visualization**
- **Add bin wrappers for new utilities**
- **Update documentation with new features**
- **Update POMS config paths to reflect poms folder structure**
- **Simplify plot_logs to merge log metrics with NERSC job counts**
- **Add mkrecovery tool for creating recovery datasets**
- **Add and update MDC2025ac job configurations**
- **Update documentation for new tools and features**
- **Add NERSC job counts data for plot_logs analysis**
- **Add generic {var} syntax for output filename substitution**
- **Improve mkrecovery to query tarball for expected files**
- **Expand MDC2025 digitization configurations**
- **Fix datasetFileList to query datasets correctly**
- **Refactor: Replace runjobdef/runfcl with runmu2e and rename map to jobdesc**
- **Clean up: Remove old pomsMapAnalyzer and runjobdef files**
- **Simplify: Consolidate push_data() and push_logs() into generic push_output()**
- **Remove unused parity test result parsing scripts**
- **Remove verbose output from setup.sh**
- **Update parity tests to use MDC2025 configs and new input_data format**
- **Update utils and POMS configuration**
- **Add pomsMonitorWeb and web interface**
- **Add web interface for POMS monitoring and job generation**
- **Add reload button to monitor and fix import consistency**
- **Simplify web interface and consolidate job generation**
- **Update evntuple.json, reco.json, pomsMonitor, digi.json, mkrecovery, and monitor.html**
- **Handle unknown job source types in jobfcl**
- **Fallback to definition files when locating jobdefs**
- **Migrate pomsMonitorWeb from in-memory to persistent database**
- **Refactor pomsMonitor.py to use persistent database instead of in-memory loading**
- **Add random sampling support to json2jobdef input file generation**
- **Refactor mkrecovery.py: fix imports and simplify path handling**
- **Refactor logparser.py: parallel processing and simplified I/O**
- **Refactor datasetFileList.py: extract definition handling and use job_common utilities**
- **Update calculate_merge_factor() to support dict format for random sampling**
- **Update build_pileup_args() to support list format for pileup_datasets**
- **Refactor jobdef.py: extract placeholder replacement and support {desc} in output filenames**
- **Clean up job_common.py: remove unused code and improve validation**
- **Add database modules for persistent POMS job monitoring**
- **Update EXAMPLES.md: add random sampling, updated mixing format, and database monitoring**
- **Fix sequencer generation for resampler/artcat jobs with random sampling**
- **Make sequencer_from_index configurable from JSON config file**
- **update to job parameters**
- **Add merge_filter.json to parity tests and improve DCache lookup**
- **Fix xroot URL conversion and njobs calculation to match Perl behavior**
- **Simplify sequencer logic: use parent run number instead of hash**
- **Fix: Upload log files even when jobs fail**
- **Include .root files in Production Monitor database**
- **Add setup script display to Production Monitor web interface**
- **Update MDC2020 event ntuple configuration**
- **Fix fcldump error for /dev/null and non-standard filenames**
- **Optimize find_missing_indices in mkrecovery**
- **Update MDC2025 digitization configuration**
- **Update MDC2025 reconstruction configuration**
- **Reduce job lifetime and timeout in fermigrid config**
- **Add shell wrapper for jobquery tool**
- **Add MDC2025 event ntuple configuration**
- **Add MDC2025 mixing configuration**
- **Handle special file paths like /dev/null in job outputs**
- **Add Mu2e Analysis Computing Organization diagram for 2025-12**
- **Update diagram: remove Normalization group, change arrows to straight lines**
- **Update diagram: swap names in Analysis Coordinators, remove Bressler from Operations Coordinators, remove subgraph box around Operations Coordinators, swap Trigger and Tools positions**
- **Fix listNewDatasets to use actual file extension instead of hardcoded .art**
- **Update data files and remove obsolete files**
- **Refactor: centralize config utilities and simplify tarball naming**
- **Fix utility modules and parity test**
- **Update MDC2025 production configs**
- **Determine mixing from config content (pbeam) instead of mix.json filename**
- **Add StashCache (CVMFS) input location support**
- **Fix FCL override precedence: move pbeam include before fcl_overrides**
- **stash location: fall back to SAM lookup if file not found on stash CVMFS**
- **Pass simjob_setup to pushOutput to ensure art environment (file_info_dumper) is available**
- **Add resilient dCache input location support (inloc: resilient)**
- **Support configurable version in jobdef tarball naming**
- **resilient location: fall back to SAM lookup if file not found on resilient dCache**
- **resilient location: use gfal2 xrootd stat instead of os.path.exists**
- **Add interactive 3D Mu2e experiment model with particle animations**
- **Update labels with detailed descriptions matching reference style**
- **Added Field Off option**
- **Added Field Off option**
- **Add retry logic to run() for transient mdh/MetaCat failures**
- **Add --extend mode to json2jobdef for delta job definitions**
- **Add --input-files query to jobquery**
- **Update beam mixing config: add keepNGenerations, bump run to 1451**
- **Add new MDC2020/MDC2025 job configurations**
- **Add unit tests for extend mode, input-files query, and event_count filter**
- **Update Operations Coordinators in diagram**
- **Update Run1B/MDC2025 configs and improve pomsMonitor analysis tools**
- **Invert dragging calculations in 3D model interaction**
- **Add interactive histogram and DIO/CE/cosmic particle tracks to 3D model**
- **Fix cosmic-spawned electrons spiraling when B-field is off**
- **Add PBI sequence workflow and prodtools extensions**
- **Add chunk_mode for on-the-fly grid chunking + wiki updates**
- **Add g4bl runner + accumulate session work (pre-refactor checkpoint)**
- **Switch g4bl runner to native AL9 spack; minimize POMS map shape**
- **g4bl runner: mdh copy-file fetch for basename-only tarballs on grid**
- **Audit cleanup round 1: DRY, silent-swallow fixes, samweb writes raise**
- **Audit cleanup round 2: Mu2eJobBase consolidation**
- **Audit cleanup round 3: json2jobdef long-function splits**
- **pomsMonitor dashboard: introduce static publish + UX improvements**
- **latestDatasets --emit: POMS-free dataset chain driver**
- **Accumulated prodtools updates: campaign configs, utils, emit-chain integration**
- **pomsMonitor: gencount column + --uniformity events/file planner**
- **MDC2025ar primaries: uniformity-optimized events/njobs**
- **chain_emit: ntuple dsconf derived from parent ({parent_dsconf})**
- **reco template: family-wide desc list, tape outloc, OffSpill entry**
- **chain_emit: --emit mix, family-wide discovery, {out_campaign} decoupling**
- **emit chain: --dsconf override, MuCap/Cat coverage, drop dead trigger streams**
- **generic_tarball cnf: skip build-time output guard; MuCap digi wide-open; Run1B fixes**
- **fcldump --dataset: discover generic cnfs (match + report)**
- **fcldump --target: generate from a generic cnf via output->input derivation**
- **cleanup: source generic-cnf tier map from chain_emit, tighten SAM query**
- **simplify: remove dead jsonexpander tool + repo-wide cleanup wins**
- **simplify: quick wins from the review session**
- **Run1Ban mixing: use published SimEfficiencies2_Run1Ban via DbService.textFile**
- **Run1Ban mixing: add FlatGamma to the signal Mix1BB entry**
- **Run1Ban mixing: add CosmicCRYAll to the signal Mix1BB entry**
- **checkpoint: full working state as of 2026-07-06**
- **cleanup: review quick wins + test hygiene**
- **wiki: lint 2026-07-06 — fix all recurring broken links**
- **simplify: apply 4-angle cleanup review (reuse/simplification/efficiency/altitude)**
- **simplify: single-home inloc→protocol table; unify template.fcl writers**
- **simplify: round-2 4-angle cleanup (capacity/SAM-path single-homing, batch locates, dedup)**
- **cleanup: remove usage-dead code (~800 lines, 3-agent investigation)**
- **docs: regenerate EXAMPLES.md from source (/refresh-examples)**
- **cleanup: loose ends — Perl echoes, list_no_child_datasets, parity docstring**
- **consolidate: single-home the input_data shape grammar (normalize_input_data)**
- **wiki: justIN vs prodtools workflow-model comparison**
- **wiki: justin-vs-prodtools — n→1 merge determinism section**
- **mix: add DIOtail95 + RPC physical pair + IPAMichel to MDC2025ar roster**
- **rmc: remake RMCInternal+External at MDC2025ap (reduced stats) + stage RMCExternalCat**
- **mix: rule — pileup inputs read from resilient, not tape**
- **wiki: Run1Ban mix recovery data-loss incident (54 outputs)**
- **jobdef: firstjob index windows — statistics expansion with fresh seeds**
- **submit: never claim success without a cluster ID; window-safe dry run**
- **fix: pomsMonitorWeb locate_file import broken by SAM single-homing**
- **hygiene: 4-agent audit batch — phantom flags, dead property, orphan fixture**
- **wiki: POMS recovery-machinery research + week's ops/incident log**
- **hygiene: tier-1 surface trims — dead symbols, locate/definitions dedup, fail() helper**
- **hygiene: tier-2 consolidations — drifted duplicates get one home**
- **wiki: NoPrimary.Run1Ban-001 remake + hygiene tiers 1+2 (with do-not-fix list)**
- **docs: fix stale Mu2eName docstring (Mu2eFilename alias was removed in 3a6b961)**
- **perf: db_builder fetches each dataset's first file once, not 3x**
- **feat: scattered-index direct recovery — submit_map --indices + mkrecovery --print-indices**
- **data: Run1B PolyFlatGamma chain (folded Selector) + NoPrimary-001 mix inputs**
- **data: MDC2025 RMCPhaseSpace primaries + CosmicCRYExtracted `as` remake chain**
- **tooling: mu2epro guard hook, /mu2epro-submit skill, mu2epro-run env notes**
- **web: histogram panel + speed slider + drag-direction fix**
- **web: geometry accuracy pass**
- **hygiene: tier-3 relocation — runner family moves from prod_utils to runmu2e**
- **wiki: tier-3 runner-family relocation logged; stale deferred items re-triaged**
- **docs: tool-retirement pass design spec (evidence-first, hard delete)**
- **docs: tool-retirement implementation plan (11 tasks, gated on verdict table)**
- **simplify: single homes, batch SAM surface, dead-parameter removal (2026-07-18 pass)**
- **audit: tool-retirement verdict table (Phase A evidence)**
- **audit: gate outcome — 5 retirements approved (incl. Flask decommission), rest KEEP**
- **retire: mkidxdef standalone CLI (json2jobdef --prod is the entry point)**
- **retire: setup_run1b.sh helper (source bin/setup.sh + MU2E_SEARCH_PATH inline instead)**
- **retire: vestigial CLI flags per 2026-07-18 verdict table**
- **web: extract /api/jobs payload builder from Flask app (pre-retirement)**
- **audit: Task 8 gate amendment — accept setup_script fix (WSGI-stub bug surfaced by byte-diff)**
- **web: render_static goes static-native (template + jobs_payload, no Flask test-client)**
- **retire: pomsMonitor Flask app + WSGI shim + JSON-editor UI (static render is the product)**
- **docs: EXAMPLES regenerated post-retirement (schema tool list pruned)**
- **wiki: tool-retirement pass logged (verdicts, charters, ops decommission)**
- **fix: final-review wave — sqlalchemy skip-guard, fail-loud empty payload, ops sync step, template stubs**
- **spec: direct-backend recovery loop design**
- **plan: direct-backend recovery loop (6 tasks, TDD)**
- **feat: submission ledger for direct-backend recovery**
- **feat: record direct submissions in the ledger**
- **feat: optional scoped index scan in build_file_maps**
- **feat: recovery-loop core — drain gate, SAM verify, capped resubmit**
- **test: direct coverage for recover.resubmit CLI contract**
- **feat: recover CLI + bin wrappers + mu2epro cron entry point**
- **fix: dry-run must not mutate ledger state**
- **docs: recovery loop — EXAMPLES regen, wiki page + runbook**
- **fix: final-review wave — verify guard, crash-window repair, run lock, drain-gate strictness**
- **docs: recover_cron comment — lock contention exits 1, not silently**
- **spec: sliced campaign submission for the direct backend**
- **spec: json2jobdef passthrough for entry resource keys**
- **plan: sliced campaign submission (6 TDD tasks)**
- **feat: campaigns table in the submission ledger**
- **feat: entry resource keys with snapshot inheritance**
- **feat: submit_map --enqueue registers sliced campaigns**
- **feat: dated submission log beside the ledger DB**
- **feat: sliced-campaign top-up phase in the recover loop**
- **docs: sliced-campaign submission — EXAMPLES regen, wiki runbook**
- **fix: final review wave — paused-campaign guard, crash-window overlap, self-heal**
- **templates: add RMCPhaseSpace0NInternal to MDC2025 mix roster**
- **spec: direct-submission workflow hardening (submissions CLI rename, ownership guard, exit-code honesty)**
- **spec: Route A amendment — retire submit_map's mu2ejobsub backend (single-backend CLI)**
- **spec: drop cross-path ownership key (POMS retirement planned) — renumber to 7 changes**
- **plan: workflow hardening — 7 TDD tasks (submissions CLI, exit honesty, single-backend)**
- **feat: rename recover -> submissions with safe-by-default verb CLI**
- **feat: exit 2 on queue-count failure and lingering paused campaigns**
- **feat: one-line operator errors for enqueue; refuse --enqueue --no-ledger**
- **feat: preserve pause notes across resume; pause --note**
- **feat: clean up child-submit scratch dirs (cron /tmp hygiene)**
- **feat: retire submit_map's mu2ejobsub backend — single-backend direct**
- **docs: submissions CLI + single-backend submit_map — runbook respell, operator quickstart, EXAMPLES regen**
- **fix: final-review wave — retire stale flag spellings in messages, help, and skills**
- **fix: parse jobsub_q default table — -af JobStatus unreliable on jobsub_lite**
- **wiki: first live direct campaign + jobsub_q -af incident**
- **wiki: htcondor bindings are present via system python, not missing**
- **fix: logs go to persistent disk, not wherever the data lands**
- **wiki: log-to-tape regression, root cause, and leave-them decision**
- **wiki: second slice submitted (cluster 70966619), dry-run reconcile verified**
- **wiki: first real recovery (index 519) scoped with --row; campaign held**
- **wiki: truncated resilient pileup file — root cause, fix, and two systemic gaps**
- **fix: never name a parents file the log push cannot find**
- **spec: input pre-flight check (resilient size + tape prestage gate)**
- **plan: input pre-flight check — 7-task TDD breakdown**
- **feat: input pre-flight — tarball input extraction (split_inputs)**
- **feat: input pre-flight — resilient size check + SAM size helper**
- **fix: input pre-flight — collapse duplicate file_sizes_in_dataset to delegation**
- **feat: input pre-flight — tape locality check (mdh)**
- **feat: input pre-flight — assemble check_inputs with inloc routing**
- **feat: input pre-flight — bin/check_inputs CLI and report**
- **feat: input pre-flight — gate submit_map --enqueue on input readiness**
- **docs: input pre-flight check (schema, EXAMPLES, wiki)**
- **fix: input pre-flight — fail-closed SAM boundary + cover tbs.samplinginput**
- **fix: bin/check_inputs was unrunnable — script-mode import path**
- **wiki: RMCPhaseSpace production resumed 1000→1500, index-519 chain closed**
- **fix: submissions drain-check fail-opened → premature recovery of running jobs**
- **wiki: log submissions drain-check fail-open incident + fix (e090116)**
- **wiki: RMCPhaseSpace 7000/7000 fully submitted; drain-check fix validated in prod**
- **spec: dataset-drain campaigns via Data Dispatcher**
- **feat(chain_emit,jobquery): per-desc emit settings; jobquery --recipe**
- **refactor(templates): one MDC2025 mix entry; per-desc merge for ~5 GB files**
- **feat(data): add MDC2025au generic reco entry**
- **fix(templates): size mix merges to ~5 GB with exact, round job counts**
- **docs(wiki): record merge-factor sizing method and its traps**
- **docs(skills): route --jobdefs by submission backend, not by directory**
- **docs(wiki): MDC2025au mix round — wave 1 submitted**
- **refactor(templates): desc as a {name: merge} mapping; merge lives once**
- **fix(check_inputs): per-file locality via mdh Python API, not the CLI**
- **refactor(stash_utils): copy with shutil.copyfile, not a cp subprocess**
- **spec: prodtools MCP stdio server**
- **spec: split prodtools MCP to read-only core; defer submission**
- **plan: prodtools MCP read-only server**
- **feat(mcp): adapters — error envelope, SystemExit trap, stdout guard**
- **feat(mcp): read-only ledger access with no DDL**
- **fix(mcp): widen ledger_ro exception handling to catch all sqlite3 errors**
- **feat(mcp): campaign_status and list_campaigns**
- **feat(mcp): find_datasets and dataset_details**
- **fix(mcp): latest_only tuple unpacking + regression guards**
- **feat(mcp): trace_provenance with a depth-bounded walk**
- **fix(mcp lineage): module-level cache singletons, cycle isolation test**
- **feat(mcp): FastMCP server wiring (server.py, tests)**
- **feat(mcp): packaging and the two-part install check**
- **fix(mcp): install.sh must not leak ops PYTHONPATH into pip**
- **fix(mcp): registration-verifying check, honest CVMFS guard, gitignore**
- **docs(mcp): register the server and document it**
- **fix(mcp): find_datasets used a glob where SAM wants a SQL LIKE**
- **fix(mcp): trace_provenance up-direction must not read a SAM outage as "primary"**
- **fix(mcp status): expose exhausted rows, one ledger snapshot, honest denominators**
- **fix(mcp): classify auth/env failures, cap find_datasets, nullable-safe schema**
- **docs(mcp): correct the plan's wrong snippets and stale counts**
- **fix(mcp): bound trace_provenance fan-out, cap find_datasets limit, classify auth by status code**
- **docs(mcp): document max_nodes/MAX_LIMIT/code-based auth fixes; correct stale famtree and line citations**
- **feat(mcp): native HTCondor queue queries with hold-reason breakdown**
- **fix(templates): size RPC merge factors by events/job, not just file size**
- **feat(submissions): give recoveries memory/lifetime headroom by default**
- **fix(runmu2e): push the log even when the data push fails**
- **fix(runmu2e): stop retrying a push failure no retry can clear**
- **fix(scopes): tape token scope named a path that does not exist**
- **feat(skills): add /joblog — fetch and triage a grid job log**
- **fix(templates): NoPrimary merge 5 -> 10 (events-bound, was under-merged)**
- **docs(joblog): record that wall-clock-held jobs leave no log at all**
- **docs(joblog): logparser first; mark condor_ssh_to_job unverified**
- **docs(joblog): condor_ssh_to_job verified working (as the job owner)**
- **Revert "NoPrimary merge 5 -> 10" -- it was based on a wrong merge factor**
- **docs(spec): latestDatasets selectable ordering — dsconf vs creation time**
- **docs(plan): latestDatasets selectable ordering — 3-task TDD plan**
- **feat(latestDatasets): injectable order key for latest-per-desc selection**
- **feat(latestDatasets): creation-date order key, contended-only**
- **feat(latestDatasets): --latest-by {dsconf,time}**
- **fix(latestDatasets): final-review fixes for --latest-by time**
- **docs(spec): record measured inversions + residual follow-ups**
- **docs(spec): confirm ac-after-ad at file level, not just definition level**
- **feat(submissions): default queue cap 10000 -> 5000**
- **docs(spec): listNewDatasets completeness from the submission ledger**
- **docs(plan): listNewDatasets ledger completeness — 3-task TDD plan**
- **feat(submissions): ledger_expected — output dataset to expected njobs**
- **feat(listNewDatasets): completeness from the submission ledger**
- **fix(spec): expected is max(njobs) across campaigns, not the sum**
- **fix(listNewDatasets): red highlight for incomplete rows, fix stale docs**
- **fix(submissions): ledger_expected takes max(njobs), not sum**
- **feat(listNewDatasets): --color {auto,always,never} for the completeness column**
- **docs(sdd): draining-campaigns spec; source-verified drainingn mechanics in wiki**
- **docs(sdd): draining-campaigns implementation plan (8 tasks) + spec refinements**
- **feat(draining): is_draining discriminator + expected_outputs_for name mapping**
- **feat(draining): enqueue input_pattern entries as draining campaigns**
- **feat(draining): submit_map --files batch dispatch, file-keyed ledger rows**
- **fix(draining): --files --dry-run must resolve the real cnf, not a stand-in**
- **feat(draining): worker files branch — direct mode runs process_direct_input**
- **fix(draining): resolve real SAM location before fetching a draining input**
- **feat(draining): pending predicate (draining_state) + fail-closed batch gates**
- **fix(draining): field-match input_pattern guard + gate/prestage coverage**
- **feat(draining): file-keyed verify_files_row + resubmit_files, kind dispatch in process_row**
- **test(draining): cover process_row's resubmit_fn dispatch + verify_files_row partial branch**
- **feat(draining): drain_tick — one gated batch per campaign per tick under the queue cap**
- **test(draining): pin drain_tick multi-campaign control flow (break/continue/cap accumulation)**
- **feat(draining): submissions complete verb, draining status lines, docs**
- **fix(draining): final-review fixes — create_date key, drain-error exit-2, per-desc scopes, status fallthrough**
- **fix(worker): never declare a job's inputs as push outputs**
- **docs(wiki): draining smoke incident — input-push near-miss + resolution**
- **feat(worker): stream inputs via xroot by default; per-entry copy_input opt-in**
- **fix(reco): au generic reco chain-matches the digi round — v1_5, not v1_1**
- **fix(mcp): campaign_status was blind to every draining campaign**
- **feat(listNewDatasets): completeness for draining campaigns**
- **feat(json2jobdef): emit a ready-to-enqueue draining map**
- **docs: update analysis computing org chart leadership**
- **feat(submissions): set-slice verb to retune a live campaign's batch size**
- **fix(samweb): chunk metadata_for_files at SAM's 1000-name limit**
- **docs: latest MDC2025 dsconf per description for dig/mcs/nts**
- **feat(submissions): set-memory verb to retune a live campaign**
- **feat(config): MDC2025au Extracted reco/ntuple + RMC PhaseSpace primaries**
- **refactor(templates): MDC2025 digi desc as {name: merge} mapping**
- **feat(skills): jobsub-rm for removing grid jobs without losing a cluster**
- **docs: trim latest-datasets to just the dataset names**
