### PR TITLE
refactor: fail loud on SAM/config errors; narrow excepts; flatten dee…

### DIFF
--- a/bin/install_prodtools.sh
+++ b/bin/install_prodtools.sh
@@ -7,6 +7,7 @@
 #               fetch/extract/mv/symlink logic without touching CVMFS.
 
 set -e
+set -o pipefail
 
 DRY_RUN=false
 TEST_MODE=false

--- a/bin/runjob.sh
+++ b/bin/runjob.sh
@@ -31,7 +31,7 @@ PRODTOOLS_DIR="$_CONDOR_SCRATCH_DIR/prodtools"
 # MU2EGRID_PRODTOOLS_TAR is the dropbox-shipped tarball's basename;
 # defaults to "prodtools.tar" for the legacy hand-crafted submission path.
 PRODTOOLS_TAR="${MU2EGRID_PRODTOOLS_TAR:-prodtools.tar}"
-tar xf "$CONDOR_DIR_INPUT/$PRODTOOLS_TAR" -C "$_CONDOR_SCRATCH_DIR"
+tar xf "$CONDOR_DIR_INPUT/$PRODTOOLS_TAR" -C "$_CONDOR_SCRATCH_DIR" || { echo "ERROR: tar failed" >&2; exit 1; }
 ls -la "$PRODTOOLS_DIR/utils/runmu2e.py" 2>&1
 
 echo "=== exec python3 runmu2e.py ==="

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -16677,3 +16677,28 @@ class TestCopyToStashCliExit(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)
+
+
+class TestInferDatasetLocationImports(unittest.TestCase):
+    """The function body imports SAMError lazily; it must execute under the
+    deployed samweb_client, which is a single module (no `.exceptions`).
+    Every _gate_batch test injects dataset_location=, so nothing else
+    runs this line."""
+
+    def test_real_function_runs_with_sam_patched(self):
+        from utils import file_resolver
+        with patch('utils.samweb_wrapper.first_file_in_definition',
+                   return_value='sim.mu2e.X.v1.001.art'), \
+             patch('utils.samweb_wrapper.locate_file_strict',
+                   return_value=[{'location': 'enstore:/pnfs/mu2e/tape/x',
+                                  'location_type': 'tape'}]):
+            self.assertEqual(file_resolver.infer_dataset_location('sim.mu2e.X.v1.art'),
+                             'enstore')
+
+    def test_sam_error_is_caught_not_import_error(self):
+        from utils import file_resolver
+        from utils.samweb_wrapper import SAMError
+        with patch('utils.samweb_wrapper.first_file_in_definition',
+                   side_effect=SAMError('SAM down')):
+            self.assertEqual(file_resolver.infer_dataset_location('sim.mu2e.X.v1.art'),
+                             'N/A')

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -1849,10 +1849,13 @@ class TestNextVersion(unittest.TestCase):
         with patch('utils.json2jobdef.files_in_dataset', return_value=files):
             self.assertEqual(_next_version(self._cfg()), 3)
 
-    def test_sam_exception_returns_zero(self):
+    def test_sam_exception_propagates(self):
+        """A SAM failure must NOT read as version 0 — that collides with an
+        existing cnf name. Fail loud instead."""
         from utils.json2jobdef import _next_version
         with patch('utils.json2jobdef.files_in_dataset', side_effect=Exception("SAM down")):
-            self.assertEqual(_next_version(self._cfg()), 0)
+            with self.assertRaises(Exception):
+                _next_version(self._cfg())
 
     def test_non_sequential_versions(self):
         from utils.json2jobdef import _next_version
@@ -10095,13 +10098,13 @@ class TestSamwebParentsOfFile(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self._wrapper(boom).parents_of_file('x.art')
 
-    def test_file_lineage_still_swallows(self):
-        """This is additive: file_lineage's callers depend on its current
-        fail-soft behaviour and must not change."""
+    def test_file_lineage_raises_on_sam_error(self):
+        """file_lineage must not swallow SAM errors: [] is a physics claim
+        ("no parents"), not an error state."""
         import inspect
         from utils.samweb_wrapper import SAMWebWrapper
         src = inspect.getsource(SAMWebWrapper.file_lineage)
-        self.assertIn('return []', src)
+        self.assertNotIn('except Exception', src)
 
 
 # ---------------------------------------------------------------------------
@@ -16489,7 +16492,9 @@ class TestSamplingInputTableIsWritten(unittest.TestCase):
         import utils.jobdef as jd
         with patch.object(jd, '_get_source_type', return_value=source_type), \
              patch.object(jd, '_get_output_modules', return_value=[]), \
-             patch.object(jd, '_seed_needed', return_value=False):
+             patch.object(jd, '_seed_needed', return_value=False), \
+             patch.object(jd, '_get_fcl_value',
+                          side_effect=subprocess.CalledProcessError(1, 'fhicl-get')):
             return jd._parse_job_args(job_args, 'template.fcl', {})
 
     def test_samplinginput_source_gets_the_table(self):

--- a/utils/datasetFileList.py
+++ b/utils/datasetFileList.py
@@ -154,27 +154,26 @@ def get_definition_files(definition_name: str) -> List[str]:
 
     return file_paths
 
+def _print_all(lines):
+    """Print each line; stop quietly when the reader (e.g. `head`) goes away."""
+    for line in lines:
+        try:
+            print(line)
+        except BrokenPipeError:
+            break
+
+
 def main():
     """Main function that replicates the exact behavior of the Perl script."""
     args = parse_args()
     dsname = args.dataset
 
     if args.basename:
-        fns = files_in_dataset(dsname)
-        for f in sorted(fns):
-            try:
-                print(f)
-            except BrokenPipeError:
-                break
+        _print_all(sorted(files_in_dataset(dsname)))
         return
 
     if args.defname:
-        file_paths = get_definition_files(dsname)
-        for final_path in file_paths:
-            try:
-                    print(final_path)
-            except BrokenPipeError:
-                break
+        _print_all(get_definition_files(dsname))
         return
 
     try:
@@ -186,14 +185,7 @@ def main():
         elif args.scratch:
             location = 'scratch'
 
-        file_paths = get_dataset_files(dsname, location)
-
-        for full_path in file_paths:
-            try:
-                print(full_path)
-            except BrokenPipeError:
-                break
-                
+        _print_all(get_dataset_files(dsname, location))
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/utils/famtree.py
+++ b/utils/famtree.py
@@ -28,6 +28,7 @@ Examples:
 import argparse
 import functools
 import os
+import sys
 
 # Package-first, bare fallback: one module identity when loaded as
 # utils.famtree (web dashboard, cron), but still works from bin/ stubs
@@ -102,8 +103,9 @@ def get_dataset_efficiency(dataset_name, samweb, max_files=10, verbosity=0):
         else:
             return (summary.passedevents, summary.genevents, summary.efficiency(), num_files_total, False)
 
-    except Exception:
-        # No gencount for this dataset, or other lookup failure.
+    except (ValueError, KeyError):
+        # No gencount / no files for this dataset (genFilterEff raises
+        # ValueError; a malformed metadata record raises KeyError).
         return None
 
 def generate_mermaid_diagram(file_name, node_id=0):
@@ -133,6 +135,21 @@ def generate_mermaid_diagram(file_name, node_id=0):
             nodes.extend(parent_data)
 
     return current_node, node_id, nodes + connections
+
+
+def _label_with_stats(lbl, samweb, cache, max_files):
+    """Node label with efficiency stats appended, when available. `cache`
+    maps dataset label -> get_dataset_efficiency result, so shared
+    ancestors (several nodes, one dataset) pay the SAM queries once."""
+    if lbl not in cache:
+        cache[lbl] = get_dataset_efficiency(lbl, samweb, max_files=max_files)
+    stats = cache[lbl]
+    if not stats:
+        return lbl
+    passed, generated, eff, num_files, is_extrapolated = stats
+    extrapolated_note = " (extrapolated)" if is_extrapolated else ""
+    return (f"{lbl}<br/>eff={eff:.4f}, trig: {passed}, gen: {generated}"
+            f"{extrapolated_note}<br/>nfiles={num_files}")
 
 
 def main():
@@ -187,16 +204,8 @@ def main():
     for part in diagram_parts:
         if isinstance(part, tuple) and len(part) == 2 and isinstance(part[0], str):
             nid, lbl = part
-
             if args.stats and samweb:
-                if lbl not in stats_cache:
-                    stats_cache[lbl] = get_dataset_efficiency(lbl, samweb, max_files=args.max_files)
-                stats = stats_cache[lbl]
-                if stats:
-                    passed, generated, eff, num_files, is_extrapolated = stats
-                    extrapolated_note = " (extrapolated)" if is_extrapolated else ""
-                    lbl = f"{lbl}<br/>eff={eff:.4f}, trig: {passed}, gen: {generated}{extrapolated_note}<br/>nfiles={num_files}"
-            
+                lbl = _label_with_stats(lbl, samweb, stats_cache, args.max_files)
             nodes.append(f'    {nid}["{lbl}"]')
         elif isinstance(part, str):
             connections.append(part)
@@ -246,8 +255,10 @@ def main():
                 convert_to_format('svg')
         except subprocess.CalledProcessError as e:
             print(f"Error converting diagram: {e}")
+            sys.exit(1)
         except FileNotFoundError:
             print("Error: mmdc command not found. Install with: npm install -g @mermaid-js/mermaid-cli")
+            sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/utils/file_resolver.py
+++ b/utils/file_resolver.py
@@ -250,8 +250,8 @@ def infer_dataset_location(dataset_name, first_file=_UNSET) -> str:
     the caller already fetched. Fail-soft for SAM-raised errors and
     malformed names only: dashboard consumers treat an unknown location
     as 'N/A', not fatal. Anything else propagates."""
-    from .samweb_wrapper import first_file_in_definition, locate_file_strict
-    from samweb_client.exceptions import Error as SAMError  # type: ignore
+    from .samweb_wrapper import (SAMError, first_file_in_definition,
+                                 locate_file_strict)
     try:
         if first_file is _UNSET:
             first_file = first_file_in_definition(dataset_name)

--- a/utils/file_resolver.py
+++ b/utils/file_resolver.py
@@ -222,7 +222,7 @@ def sam_physical_path_or_none(filename, prefer_location=None):
     takes a cnf DEFNAME and raises."""
     try:
         return sam_physical_path(filename, prefer_location)
-    except Exception:
+    except (ValueError, RuntimeError):
         return None
 
 
@@ -247,9 +247,11 @@ _UNSET = object()
 def infer_dataset_location(dataset_name, first_file=_UNSET) -> str:
     """Normalized storage location (dcache/enstore/N/A) of a dataset from
     its first file's SAM location records. Pass first_file to reuse one
-    the caller already fetched. Fail-soft: dashboard consumers treat an
-    unknown location as 'N/A', not fatal."""
+    the caller already fetched. Fail-soft for SAM-raised errors and
+    malformed names only: dashboard consumers treat an unknown location
+    as 'N/A', not fatal. Anything else propagates."""
     from .samweb_wrapper import first_file_in_definition, locate_file_strict
+    from samweb_client.exceptions import Error as SAMError  # type: ignore
     try:
         if first_file is _UNSET:
             first_file = first_file_in_definition(dataset_name)
@@ -262,7 +264,7 @@ def infer_dataset_location(dataset_name, first_file=_UNSET) -> str:
             full_path = entry.get('full_path')
             if full_path:
                 return classify_sam_location(full_path)
-    except Exception as e:
+    except (SAMError, ValueError) as e:
         print(f"Warning: infer_dataset_location failed for {dataset_name}: {e}",
               file=sys.stderr)
     return 'N/A'
@@ -340,15 +342,16 @@ class FileResolver:
         todo = [f for f in filenames if f not in self._location_cache]
         if not todo:
             return
+        from .samweb_wrapper import locate_files_strict
         try:
-            from .samweb_wrapper import locate_files_strict
             result = locate_files_strict(todo)
-            if isinstance(result, dict):
-                for fname, locs in result.items():
-                    if isinstance(locs, list):
-                        self._location_cache[fname] = locs
-        except Exception:
-            pass
+        except (ValueError, RuntimeError, KeyError):
+            return
+        if not isinstance(result, dict):
+            return
+        self._location_cache.update(
+            {fname: locs for fname, locs in result.items()
+             if isinstance(locs, list)})
 
     def locate(self, filename: str) -> str:
         """Physical path for a file (no protocol formatting)."""

--- a/utils/genFilterEff.py
+++ b/utils/genFilterEff.py
@@ -34,11 +34,12 @@ class DatasetEffSummary:
         self.passedevents = 0
     
     def fill(self, metadata):
-        """Add one file's SAM metadata dict to the summary."""
-        self.nfiles += 1
-
+        """Add one file's SAM metadata dict to the summary. A file with no
+        dh.gencount raises before it is counted, so nfiles stays the
+        denominator of files actually summed."""
         if 'dh.gencount' not in metadata:
             raise ValueError(f"Error: no dh.gencount in metadata for file {metadata.get('file_name', 'unknown')}")
+        self.nfiles += 1
 
         self.genevents += metadata['dh.gencount']
 
@@ -88,7 +89,7 @@ def process_dataset(dsname, samweb, chunk_size=100, max_files=None, verbosity=2)
         for metadata in chunk_metadata:
             try:
                 summary.fill(metadata)
-            except Exception as e:
+            except ValueError as e:
                 print(f"Warning: Error processing file "
                       f"{metadata.get('file_name', 'unknown')}: {e}", file=sys.stderr)
                 continue
@@ -177,13 +178,13 @@ def main():
                 verbosity=args.verbosity
             )
             summaries.append(summary)
-        except Exception as e:
+        except ValueError as e:
             print(f"Error processing dataset {dataset}: {e}", file=sys.stderr)
             sys.exit(1)
 
     try:
         write_output(summaries, args.outfile, args.firstLine, args.writeFullDatasetName)
-    except Exception as e:
+    except (FileExistsError, OSError) as e:
         print(f"Error writing output: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/utils/job_common.py
+++ b/utils/job_common.py
@@ -378,28 +378,40 @@ class Mu2eJobBase:
                 nreq = len(infiles)
 
             if sequential_aux:
-                nf = len(infiles)
-                first = index * nreq
-                last = min(first + nreq - 1, nf - 1)
-                if first >= nf:
-                    first = first % nf
-                    last = min(first + nreq - 1, nf - 1)
-                if first > last:
-                    raise ValueError(f"job_aux_inputs(): invalid index {index} for sequential selection")
-                result[dataset] = infiles[first:last + 1]
+                result[dataset] = self._sequential_slice(infiles, nreq, index)
             else:
-                sample = []
-                available_files = infiles.copy()
-                for _ in range(nreq):
-                    if not available_files:
-                        break
-                    rnd = self._my_random(index, *available_files)
-                    file_index = rnd % len(available_files)
-                    sample.append(available_files[file_index])
-                    available_files.pop(file_index)
-                result[dataset] = sample
+                result[dataset] = self._sampled(infiles, nreq, index)
 
         return result
+
+    @staticmethod
+    def _sequential_slice(infiles, nreq, index):
+        """`nreq` files starting at index*nreq, rolling over past the end."""
+        nf = len(infiles)
+        first = index * nreq
+        last = min(first + nreq - 1, nf - 1)
+        if first >= nf:
+            first = first % nf
+            last = min(first + nreq - 1, nf - 1)
+        if first > last:
+            raise ValueError(f"job_aux_inputs(): invalid index {index} for sequential selection")
+        return infiles[first:last + 1]
+
+    def _sampled(self, infiles, nreq, index):
+        """`nreq` files sampled without repetition. The
+        `_my_random(index, *available_files)` call order is a seed
+        contract with mu2ejobfcl — do not change the argument order or
+        the number of calls."""
+        sample = []
+        available_files = infiles.copy()
+        for _ in range(nreq):
+            if not available_files:
+                break
+            rnd = self._my_random(index, *available_files)
+            file_index = rnd % len(available_files)
+            sample.append(available_files[file_index])
+            available_files.pop(file_index)
+        return sample
 
     def job_sampling_inputs(self, index):
         """Sampling input files for job index.

--- a/utils/jobdef.py
+++ b/utils/jobdef.py
@@ -101,9 +101,9 @@ def _seed_needed(template_path: str) -> bool:
     """True if services.SeedService is configured (Perl seedNeeded() parity)."""
     try:
         svclist = _run_fhicl_get(template_path, '--names-in', 'services')
-        return sum(1 for service in svclist.split('\n') if service == 'SeedService')
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return 0  # fhicl-get failure/absence -> not needed (Perl's 2>/dev/null)
+        return any(service == 'SeedService' for service in svclist.split('\n'))
+    except subprocess.CalledProcessError:
+        return False  # no services block -> not needed (Perl's 2>/dev/null)
 
 
 def _get_output_modules(template_path: str) -> List[str]:
@@ -130,7 +130,7 @@ def _get_output_modules(template_path: str) -> List[str]:
             for m in mods:
                 if m:
                     endmodules.add(m)
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except subprocess.CalledProcessError:
             continue
 
     active_outmods = []
@@ -501,7 +501,7 @@ def _parse_job_args(job_args: List[str], template_path: str, config: Dict = None
         if tfileservice_filename and tfileservice_filename.strip() and tfileservice_filename.strip() != '/dev/null':
             defer_keys = config.get('_defer_keys', set()) if config else set()
             _add_outfile(tbs, 'services.TFileService.fileName', tfileservice_filename, config, defer_keys=defer_keys)
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except subprocess.CalledProcessError:
         pass  # not defined; skip
 
     if args_state['auxin']:
@@ -559,15 +559,19 @@ def get_output_dataset_names(config: Dict) -> List[str]:
             try:
                 pattern = _run_fhicl_get(
                     template_path, '--atom-as', f'outputs.{mod}.fileName')
-                resolved = _replace_placeholders(pattern, config)
-                try:
-                    n = Mu2eName.parse(resolved)
-                except ValueError:
-                    continue
-                if n.is_file:
-                    datasets.append(str(n.dataset))
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as e:
+                # An output module on an end path with no fileName is a
+                # template bug, not an "unknown dataset".
+                raise RuntimeError(
+                    f"active output module '{mod}' has no outputs.{mod}.fileName "
+                    f"in {fcl_path}") from e
+            resolved = _replace_placeholders(pattern, config)
+            try:
+                n = Mu2eName.parse(resolved)
+            except ValueError:
                 continue
+            if n.is_file:
+                datasets.append(str(n.dataset))
     finally:
         if os.path.exists(template_path):
             os.unlink(template_path)

--- a/utils/jobdef_lookup.py
+++ b/utils/jobdef_lookup.py
@@ -17,6 +17,7 @@ cnf's *declared* outputs (handles the suffixed-output case, e.g. cnf desc
 
 import os
 import sys
+import tarfile
 
 from utils.job_common import Mu2eName
 from utils.samweb_wrapper import definitions_matching
@@ -44,23 +45,18 @@ def list_jobdefs(dsconf):
     pattern = f"cnf.mu2e.%.{dsconf}.tar"
     _log(f"Searching for job definitions with pattern: cnf.mu2e.*.{dsconf}.tar")
 
-    try:
-        definitions = definitions_matching(defname=pattern)
+    definitions = definitions_matching(defname=pattern)
 
-        if not definitions:
-            _log(f"No job definitions found for dsconf: {dsconf}")
-            return []
-
-        _log(f"Found {len(definitions)} job definitions:")
-        for definition in definitions:
-            if definition.strip():
-                _log(f"  {definition}")
-
-        return definitions
-
-    except Exception as e:
-        _log(f"Error accessing SAM: {e}")
+    if not definitions:
+        _log(f"No job definitions found for dsconf: {dsconf}")
         return []
+
+    _log(f"Found {len(definitions)} job definitions:")
+    for definition in definitions:
+        if definition.strip():
+            _log(f"  {definition}")
+
+    return definitions
 
 
 def _raw_outfile_descs(tarball_path):
@@ -72,7 +68,9 @@ def _raw_outfile_descs(tarball_path):
     out = []
     try:
         outfiles = Mu2eJobPars(tarball_path).json_data.get('tbs', {}).get('outfiles', {})
-    except Exception:
+    except (tarfile.TarError, OSError, KeyError) as e:
+        print(f"jobdef_lookup: cannot read outfiles from {tarball_path}: {e}",
+              file=sys.stderr)
         return out
     for template in (outfiles or {}).values():
         try:
@@ -219,9 +217,10 @@ def _search_jobdefs(jobdefs, desc, input_type, name_filter, verbose_match=False)
 
         try:
             outputs = Mu2eJobPars(tarball_path).job_outputs(0)
-        except Exception as e:
-            # Generic tarballs defer {desc}/sequencer -> job_outputs() raises.
-            # They are handled by the generic pass; skip here, don't abort.
+        except ValueError as e:
+            # Generic tarballs defer {desc}/sequencer -> job_outputs() raises
+            # ValueError (get_sequencer / Mu2eName.parse). They are handled
+            # by the generic pass; skip here, don't abort.
             _log(f"Skipping {jobdef} in output scan ({e})")
             continue
         for output_file in outputs.values():
@@ -249,26 +248,21 @@ def locate_tarball(jobdef):
     _log(f"Using datasetFileList to locate: {jobdef}")
 
     try:
-        try:
-            file_paths = get_dataset_files(jobdef)
-        except RuntimeError as e:
-            if "No files with dh.dataset" in str(e):
-                file_paths = get_definition_files(jobdef)
-            else:
-                raise
+        file_paths = get_dataset_files(jobdef)
+    except RuntimeError as e:
+        if "No files with dh.dataset" not in str(e):
+            raise
+        file_paths = get_definition_files(jobdef)
 
-        if not file_paths:
-            raise RuntimeError(f"Tarball not found for: {jobdef}")
+    if not file_paths:
+        raise RuntimeError(f"Tarball not found for: {jobdef}")
 
-        tarball_path = file_paths[0]
-        if not os.path.exists(tarball_path):
-            raise RuntimeError(f"Tarball not found for: {jobdef}")
+    tarball_path = file_paths[0]
+    if not os.path.exists(tarball_path):
+        raise RuntimeError(f"Tarball not found for: {jobdef}")
 
-        _log(f"Found tarball at: {tarball_path}")
-        return tarball_path
-
-    except Exception as e:
-        raise RuntimeError(f"Error locating tarball for {jobdef}: {e}")
+    _log(f"Found tarball at: {tarball_path}")
+    return tarball_path
 
 
 def output_njobs_map(dsconf):
@@ -288,7 +282,7 @@ def output_njobs_map(dsconf):
             njobs = jp.njobs()
             outputs = jp.job_outputs(0)
         except Exception as e:
-            _log(f"Skipping {jobdef}: {e}")
+            print(f"jobdef_lookup: skipping {jobdef}: {e}", file=sys.stderr)
             continue
         for output_file in outputs.values():
             try:

--- a/utils/jobfcl.py
+++ b/utils/jobfcl.py
@@ -16,6 +16,8 @@ from utils.file_resolver import FileResolver
 
 _OUTPUT_FILENAME_KEY_RE = re.compile(r'^outputs\.\w+\.fileName$')
 _PLACEHOLDER_TOKEN_RE = re.compile(r'\b(description|desc|owner|version|sequencer)\b')
+_SOURCE_MODULE_TYPE_RE = re.compile(r'module_type\s*:\s*(\w+)')
+_KNOWN_SOURCE_TYPES = ('SamplingInput', 'RootInput', 'EmptyEvent')
 
 
 def _check_output_filenames_substituted(outputs_dict: Dict[str, str], jobdef_name: str = "") -> None:
@@ -58,14 +60,11 @@ class Mu2eJobFCL(Mu2eJobBase):
         """Detect the source module type from the base FCL."""
         if self._source_type is None:
             base_fcl = self._extract_fcl()
-            if 'module_type : SamplingInput' in base_fcl or 'module_type: SamplingInput' in base_fcl:
-                self._source_type = 'SamplingInput'
-            elif 'module_type : RootInput' in base_fcl or 'module_type: RootInput' in base_fcl:
-                self._source_type = 'RootInput'
-            elif 'module_type : EmptyEvent' in base_fcl or 'module_type: EmptyEvent' in base_fcl:
-                self._source_type = 'EmptyEvent'
-            else:
-                self._source_type = 'Unknown'
+            # Same precedence as the historical string checks: first known
+            # source type found anywhere in the file wins, in this order.
+            found = set(_SOURCE_MODULE_TYPE_RE.findall(base_fcl))
+            self._source_type = next(
+                (t for t in _KNOWN_SOURCE_TYPES if t in found), 'Unknown')
         return self._source_type
     
     def _extract_fcl(self) -> str:

--- a/utils/jobquery.py
+++ b/utils/jobquery.py
@@ -42,11 +42,11 @@ class Mu2eJobPars(Mu2eJobBase):
 
         for section in ('inputs', 'auxin'):
             for value in tbs.get(section, {}).values():
-                if isinstance(value, list) and len(value) >= 2:
-                    _, file_list = value
-                    dataset = extract_dataset_from_files(file_list)
-                    if dataset:
-                        datasets.add(dataset)
+                if not isinstance(value, list) or len(value) < 2:
+                    continue
+                dataset = extract_dataset_from_files(value[1])
+                if dataset:
+                    datasets.add(dataset)
 
         return list(datasets)
     
@@ -55,11 +55,11 @@ class Mu2eJobPars(Mu2eJobBase):
         tbs = self.json_data.get('tbs', {})
         files = []
         for section in ('inputs', 'samplinginput', 'auxin'):
-            for key, value in tbs.get(section, {}).items():
-                if isinstance(value, list) and len(value) >= 2:
-                    file_list = value[1]
-                    if isinstance(file_list, list):
-                        files.extend(file_list)
+            for value in tbs.get(section, {}).values():
+                if not isinstance(value, list) or len(value) < 2:
+                    continue
+                if isinstance(value[1], list):
+                    files.extend(value[1])
         return files
     
     def output_datasets(self):
@@ -177,6 +177,32 @@ file cnf.tar. The possible queries are:
 """
 
 
+def _output_files(jp, spec):
+    """--output-files <dsname>[:listsize]: print the files of one dataset."""
+    if ':' in spec:
+        dataset_name, size_str = spec.split(':', 1)
+        try:
+            list_size = int(size_str)
+        except ValueError:
+            print(f"Error: Invalid list size: {size_str}")
+            sys.exit(1)
+    else:
+        dataset_name = spec
+        list_size = None
+
+    if dataset_name not in jp.output_datasets():
+        print(f"Error: Dataset {dataset_name} is not produced by the job set")
+        sys.exit(1)
+
+    for filename in jp.output_files(dataset_name, list_size):
+        print(filename)
+
+
+def _print_lines(lines):
+    for line in lines:
+        print(line)
+
+
 def main():
     """Main function"""
     parser = argparse.ArgumentParser(description='Extract information from Mu2e job parameter files')
@@ -210,61 +236,25 @@ def main():
     
     try:
         jp = Mu2eJobPars(args.parfile)
-        
-        if args.jobname:
-            print(jp.jobname())
-        
-        elif args.njobs:
-            print(jp.njobs())
-        
-        elif args.input_datasets:
-            for dataset in jp.input_datasets():
-                print(dataset)
-        
-        elif args.input_files:
-            for f in jp.input_files():
-                print(f)
-        
-        elif args.output_datasets:
-            for dataset in jp.output_datasets():
-                print(dataset)
-        
-        elif args.output_files:
-            # dataset[:size] format
-            if ':' in args.output_files:
-                dataset_name, size_str = args.output_files.split(':', 1)
-                try:
-                    list_size = int(size_str)
-                except ValueError:
-                    print(f"Error: Invalid list size: {size_str}")
-                    sys.exit(1)
-            else:
-                dataset_name = args.output_files
-                list_size = None
 
-            if dataset_name not in jp.output_datasets():
-                print(f"Error: Dataset {dataset_name} is not produced by the job set")
-                sys.exit(1)
+        dispatch = {
+            'jobname':         lambda: print(jp.jobname()),
+            'njobs':           lambda: print(jp.njobs()),
+            'input_datasets':  lambda: _print_lines(jp.input_datasets()),
+            'input_files':     lambda: _print_lines(jp.input_files()),
+            'output_datasets': lambda: _print_lines(jp.output_datasets()),
+            'codesize':        lambda: print(jp.codesize()),
+            'setup':           lambda: print(jp.setup()),
+            'recipe':          lambda: print(jp.recipe()),
+        }
+        if args.output_files is not None:
+            _output_files(jp, args.output_files)
+        else:
+            flag = next(f for f in dispatch if getattr(args, f))
+            dispatch[flag]()
 
-            try:
-                files = jp.output_files(dataset_name, list_size)
-                for filename in files:
-                    print(filename)
-            except ValueError as e:
-                print(f"Error: {e}")
-                sys.exit(1)
-        
-        elif args.codesize:
-            print(jp.codesize())
-
-        elif args.setup:
-            print(jp.setup())
-
-        elif args.recipe:
-            print(jp.recipe())
-    
     except Exception as e:
-        print(f"Error: {e}")
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/utils/jobsub_argv.py
+++ b/utils/jobsub_argv.py
@@ -83,13 +83,14 @@ def output_storage_dirs(output_filenames, outputs):
     import fnmatch
     dirs = set()
     for fname in output_filenames or []:
-        for spec in outputs or []:
-            pattern = spec.get("dataset") or "*"
-            if fnmatch.fnmatch(fname, pattern):
-                scope = storage_scope_for_file(fname, spec.get("location"))
-                if scope:
-                    dirs.add(scope)
-                break
+        spec = next((spec for spec in outputs or []
+                     if fnmatch.fnmatch(fname, spec.get("dataset") or "*")),
+                    None)
+        if spec is None:
+            continue
+        scope = storage_scope_for_file(fname, spec.get("location"))
+        if scope:
+            dirs.add(scope)
     return sorted(dirs)
 
 
@@ -98,23 +99,16 @@ def output_storage_dirs(output_filenames, outputs):
 def description_from_tarball(tarball_name):
     """`cnf.<owner>.<desc>.<dsconf>.<seq>.tar` → `<desc>`.
 
-    Lenient: unparseable names fall back to the raw basename.
+    Raises ValueError on an unparseable name (tarball_of already
+    rejects those at the entry boundary).
     """
-    bn = os.path.basename(tarball_name)
-    try:
-        return Mu2eName.parse(bn).description
-    except ValueError:
-        return bn
+    return Mu2eName.parse(os.path.basename(tarball_name)).description
 
 
 def campaign_from_tarball(tarball_name):
     """`cnf.<owner>.<desc>.<dsconf>.<seq>.tar` → MDC campaign token in `<dsconf>`,
-    else the full `<dsconf>`. Lenient: unparseable names → 'default'."""
-    bn = os.path.basename(tarball_name)
-    try:
-        n = Mu2eName.parse(bn)
-    except ValueError:
-        return "default"
+    else the full `<dsconf>`. Raises ValueError on an unparseable name."""
+    n = Mu2eName.parse(os.path.basename(tarball_name))
     m = re.match(r"(MDC\d{4})", n.dsconf)
     return m.group(1) if m else n.dsconf
 

--- a/utils/json2jobdef.py
+++ b/utils/json2jobdef.py
@@ -41,6 +41,8 @@ def _random_selection(files, total_needed: int, seed_source: str):
     ordered = sorted(files)  # sort first: deterministic regardless of SAM order
     rng = random.Random(seed_source)
     rng.shuffle(ordered)
+    if not ordered:
+        return []
     count = len(ordered)
     return [ordered[i % count] for i in range(total_needed)]
 

--- a/utils/json2jobdef.py
+++ b/utils/json2jobdef.py
@@ -36,19 +36,13 @@ from utils.samweb_wrapper import (
 )
 
 
-def _write_random_selection(out_f, files, total_needed: int, seed_source: str):
-    """Write deterministic pseudo-random selection from a fetched file list."""
+def _random_selection(files, total_needed: int, seed_source: str):
+    """Deterministic pseudo-random selection from a fetched file list."""
     ordered = sorted(files)  # sort first: deterministic regardless of SAM order
     rng = random.Random(seed_source)
     rng.shuffle(ordered)
-
-    produced = 0
-    idx = 0
     count = len(ordered)
-    while produced < total_needed:
-        out_f.write(ordered[idx] + '\n')
-        produced += 1
-        idx = (idx + 1) % count
+    return [ordered[i % count] for i in range(total_needed)]
 
 def _configure_chunk_mode(config):
     """Handle `input_data = {"<path>": {"chunk_lines": N}}`.
@@ -216,39 +210,54 @@ def _write_sam_inputs(config, input_data, exclude_files=None):
                 raise ValueError(f"input_data spec for {spec.source} must include 'count' or 'merge_factor' when using dict form")
 
             query = q_dataset(spec.source, with_events=event_count_positive)
-
             if spec.random:
-                per_job = spec.per_job
-                try:
-                    njobs = int(config.get('njobs', 1))
-                except (TypeError, ValueError):
-                    njobs = 1
-
-                # One SAM query serves njobs derivation and selection
-                # (previously count_files + list_files ran it twice).
-                files = list_files(query)
-                if not files:
-                    raise ValueError(f"No files returned for query: {query}")
-
-                if njobs == -1:
-                    njobs = max(1, len(files) // max(per_job, 1))
-
-                total_needed = per_job * max(njobs, 1)
-                if spec.max_nfiles is not None:
-                    total_needed = min(total_needed, spec.max_nfiles)
-                seed_source = (
-                    f"{config.get('owner','')}.{config.get('desc','')}.{config.get('dsconf','')}"
-                    f".{spec.source}.{per_job}.{njobs}"
-                )
-                _write_random_selection(out_f, files, total_needed, seed_source)
+                files = _random_files(config, spec, query)
             else:
-                files = list_files(query)
-                if spec.max_nfiles is not None:
-                    files = sorted(files)[:spec.max_nfiles]
-                for filepath in files:
-                    if exclude_files and filepath in exclude_files:
-                        continue
-                    out_f.write(filepath + '\n')
+                files = _ordered_files(spec, query, exclude_files)
+            for filepath in files:
+                out_f.write(filepath + '\n')
+
+
+def _random_files(config, spec, query):
+    """Deterministic pseudo-random sample of `per_job * njobs` files (capped by
+    `max_nfiles`), cycling the sorted+shuffled list when it is shorter."""
+    per_job = spec.per_job
+    raw_njobs = config.get('njobs', 1)
+    try:
+        njobs = int(raw_njobs)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"njobs must be an integer for random input selection of "
+            f"{spec.source}; got {raw_njobs!r}")
+
+    # One SAM query serves njobs derivation and selection
+    # (previously count_files + list_files ran it twice).
+    files = list_files(query)
+    if not files:
+        raise ValueError(f"No files returned for query: {query}")
+
+    if njobs == -1:
+        njobs = max(1, len(files) // max(per_job, 1))
+
+    total_needed = per_job * max(njobs, 1)
+    if spec.max_nfiles is not None:
+        total_needed = min(total_needed, spec.max_nfiles)
+    seed_source = (
+        f"{config.get('owner','')}.{config.get('desc','')}.{config.get('dsconf','')}"
+        f".{spec.source}.{per_job}.{njobs}"
+    )
+    return _random_selection(files, total_needed, seed_source)
+
+
+def _ordered_files(spec, query, exclude_files=None):
+    """All matching files in SAM order (sorted prefix when `max_nfiles` caps
+    them), minus `exclude_files`."""
+    files = list_files(query)
+    if spec.max_nfiles is not None:
+        files = sorted(files)[:spec.max_nfiles]
+    if exclude_files:
+        files = [f for f in files if f not in exclude_files]
+    return files
 
 def _next_version(config):
     """Find the next available version number for this job definition tarball.
@@ -258,11 +267,7 @@ def _next_version(config):
     """
     dataset = cnf_name(config, 'tar', dataset=True)
 
-    try:
-        files = files_in_dataset(dataset)
-    except Exception:
-        return 0
-
+    files = files_in_dataset(dataset)
     if not files:
         return 0
 
@@ -324,13 +329,10 @@ def validate_required_fields(config):
     # setup script, or a code tarball that travels with the job.
     if bool(config.get('simjob_setup')) == bool(config.get('code')):
         sys.exit("Exactly one of 'simjob_setup' and 'code' is required")
-    for key in ENTRY_VALUE_KEYS:
-        if key in config:
-            try:
-                validate_entry_value(key, config[key])
-            except ValueError as exc:
-                sys.exit(f"json2jobdef: {exc}")
     try:
+        for key in ENTRY_VALUE_KEYS:
+            if key in config:
+                validate_entry_value(key, config[key])
         validate_outloc(config['outloc'])
     except ValueError as exc:
         sys.exit(f"json2jobdef: {exc}")
@@ -600,11 +602,14 @@ def _build_job_args(config):
         # rather than feed a basename into a SAM lookup that can only fail.
         # build_jobdef mirrors this guard when emitting post_lines.
         if not _is_dir_inloc(config):
+            # A resampler cnf without MaxEventsToSkip is a physics bug (the
+            # resampler silently re-reads the same leading events), so a
+            # failed lookup is fatal, not a warning.
             first_dataset = normalize_input_data(config['input_data'])[0].source
             try:
                 config['_max_events_to_skip'] = max_events_to_skip(first_dataset)
             except Exception as e:
-                print(f"Warning: Could not calculate MaxEventsToSkip for {first_dataset}: {e}")
+                fail(f"Error: Could not calculate MaxEventsToSkip for {first_dataset}: {e}")
         merge_factor = calculate_merge_factor(config)
         return ['--auxinput', f"{merge_factor}:physics.filters.{config['resampler_name']}.fileNames:inputs.txt"]
 
@@ -908,9 +913,9 @@ def process_all_for_dsconf(expanded_configs, dsconf, args):
     # left alone (already in SAM/ledger; undoing them is not this call).
     if skipped:
         print(f"\n{len(skipped)} of {len(matching_configs)} entries were "
-              f"SKIPPED and no campaign exists for them:")
+              f"SKIPPED and no campaign exists for them:", file=sys.stderr)
         for note in skipped:
-            print(f"  - {note}")
+            print(f"  - {note}", file=sys.stderr)
         sys.exit(2)
 
 if __name__ == '__main__':

--- a/utils/latestDatasets.py
+++ b/utils/latestDatasets.py
@@ -180,15 +180,18 @@ def _narrow_to_latest_release(names):
     discovers every release (MDC2025aa..MDC2025ap); the chain processes
     one."""
     rel = {}
+    skipped = []
     for n in names:
-        try:
-            rel[n] = Mu2eName.parse(n).campaign
-        except ValueError:
-            pass
+        if parse_name(n) is None:
+            skipped.append(n)
+            continue
+        rel[n] = Mu2eName.parse(n).campaign
     if not rel:
         return names
     latest = max(rel.values())  # campaign tags sort lexicographically
-    return [n for n in names if rel.get(n) == latest]
+    # Unparseable names are kept (not silently dropped), as in
+    # _group_by_description / _filter_complete.
+    return [n for n in names if rel.get(n) == latest] + skipped
 
 
 def _filter_complete(names):
@@ -223,18 +226,17 @@ def _filter_complete(names):
                 kept.append(ds)
             else:
                 _vlog(f"# incomplete (skipped): {ds}")
-        except Exception as e:
-            _vlog(f"# completeness indeterminate (included): {ds}: {e}")
+        except (ValueError, RuntimeError) as e:
+            print(f"# completeness indeterminate (included): {ds}: {e}",
+                  file=sys.stderr)
             kept.append(ds)
     return kept
 
 
 def _dataset_exists(name):
-    """True if the SAM dataset has at least one file."""
-    try:
-        return dataset_file_count(name) > 0
-    except Exception:
-        return False
+    """True if the SAM dataset has at least one file. A SAM failure
+    propagates: a false 'unproduced' would re-run the stage."""
+    return dataset_file_count(name) > 0
 
 
 def _filter_unproduced(inputs, template, out_campaign=None, defer_desc=False,

--- a/utils/listNewDatasets.py
+++ b/utils/listNewDatasets.py
@@ -2,6 +2,7 @@
 """List recently created datasets from SAM database."""
 
 import os
+import sqlite3
 import sys
 import argparse
 from datetime import datetime, timedelta
@@ -87,14 +88,18 @@ class DatasetLister:
             dataset_counts[dataset] += 1
         return dict(dataset_counts)
 
-    def _total_files(self, dataset: str) -> int:
-        """Total files in the dataset. NOT the windowed COUNT column: a
-        campaign started before the lookback window would otherwise score a
-        full-campaign denominator against a partial numerator."""
+    def _total_files(self, dataset: str) -> Optional[int]:
+        """Total files in the dataset, or None when SAM could not answer
+        (rendered as '?', never a fabricated 0). NOT the windowed COUNT
+        column: a campaign started before the lookback window would
+        otherwise score a full-campaign denominator against a partial
+        numerator."""
         try:
             return dataset_file_count(dataset)
-        except Exception:
-            return 0
+        except (ValueError, RuntimeError) as e:
+            print(f"WARNING: file count failed for {dataset}: {e}",
+                  file=sys.stderr)
+            return None
 
     def _get_completeness(self, dataset: str) -> str:
         """<landed>/<expected> for a dataset produced by a direct campaign.
@@ -119,6 +124,8 @@ class DatasetLister:
         if expected is None:
             return "—"
         landed = self._total_files(dataset)
+        if landed is None:
+            return f"?/{expected}"
         text = f"{landed}/{expected}"
         if landed >= expected:
             return text
@@ -150,7 +157,7 @@ class DatasetLister:
                 self._expected, failures = ledger_expected(
                     self.ledger_db, dsconfs=dsconfs,
                     datasets={ds for ds, _ in sorted_datasets})
-            except Exception as e:
+            except (sqlite3.Error, OSError) as e:
                 print(f"WARNING: could not read ledger {self.ledger_db} ({e}); "
                       "completeness column disabled.", file=sys.stderr)
                 self.completeness = False

--- a/utils/logparser.py
+++ b/utils/logparser.py
@@ -14,16 +14,12 @@ MEMREPORT_REGEX = re.compile(r"MemReport\s+VmPeak\s*=\s*([0-9]*\.?[0-9]+)\s+VmHW
 
 def get_log_files(dataset, max_files=None):
     """Get log files for a SAM dataset (e.g., log.mu2e.X.Y.log). dataset must
-    be registered with dh.dataset metadata. Returns [] if not found."""
-    try:
-        # get_dataset_files() constructs paths directly, no locate_files()
-        # calls; max_files caps that at the source (a log dataset holds one
-        # file per job — up to 100k names for a 10-log sample otherwise).
-        return get_dataset_files(dataset, max_files=max_files)
-
-    except Exception as e:
-        print(f"Warning: get_log_files failed for {dataset}: {e}", file=sys.stderr)
-        return []
+    be registered with dh.dataset metadata. Raises RuntimeError (from
+    get_dataset_files) when the dataset cannot be resolved."""
+    # get_dataset_files() constructs paths directly, no locate_files()
+    # calls; max_files caps that at the source (a log dataset holds one
+    # file per job — up to 100k names for a 10-log sample otherwise).
+    return get_dataset_files(dataset, max_files=max_files)
 
 def parse_log_file(filepath):
     """Extract CPU, Real, VmPeak and VmHWM from a log file."""
@@ -49,11 +45,13 @@ def process_dataset(dataset, max_logs, max_workers=10):
     max_workers is the thread pool size for parallel log parsing."""
     print(f"Processing {dataset}", file=sys.stderr)
     
-    log_files = get_log_files(dataset, max_logs)
+    try:
+        log_files = get_log_files(dataset, max_logs)
+    except RuntimeError as e:
+        print(f"Error: get_log_files failed for {dataset}: {e}", file=sys.stderr)
+        return {'dataset': dataset, 'error': str(e)}
     if not log_files:
-        return {'dataset': dataset, 'CPU [h]': None, 'CPU_max [h]': None,
-                'Real [h]': None, 'Real_max [h]': None, 'VmPeak [GB]': None,
-                'VmPeak_max [GB]': None, 'VmHWM [GB]': None, 'VmHWM_max [GB]': None}
+        return {'dataset': dataset, 'error': 'no log files found'}
     
     file_metrics = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -67,16 +65,6 @@ def process_dataset(dataset, max_logs, max_workers=10):
             except Exception as e:
                 log_file = future_to_file[future]
                 print(f"Warning: Error parsing {log_file}: {e}", file=sys.stderr)
-                # keep an empty placeholder so ordering/count stays intact
-                file_metrics.append({
-                    'file': os.path.basename(log_file),
-                    'full_path': log_file,
-                    'date': 'N/A',
-                    'CPU [h]': None,
-                    'Real [h]': None,
-                    'VmPeak [GB]': None,
-                    'VmHWM [GB]': None
-                })
     
     metrics = {'CPU': [], 'Real': [], 'VmPeak': [], 'VmHWM': []}
     for fm in file_metrics:

--- a/utils/prod_utils.py
+++ b/utils/prod_utils.py
@@ -121,7 +121,9 @@ def get_def_counts(dataset):
     Exits when the dataset has no such files."""
     nfiles = definition_file_count(dataset, with_events=True)
     result = dataset_summary(dataset)
-    nevts = (result.get('total_event_count') or 0) if isinstance(result, dict) else 0
+    if not isinstance(result, dict):
+        raise RuntimeError(f"dataset_summary({dataset}) returned {result!r}, expected a dict")
+    nevts = result.get('total_event_count') or 0
 
     if nfiles == 0:
         sys.exit(f"No files found in dataset {dataset}")

--- a/utils/runlocal.py
+++ b/utils/runlocal.py
@@ -257,7 +257,7 @@ def kill_job(proc, log=None):
     for sig in (signal.SIGTERM, signal.SIGKILL):
         try:
             os.killpg(proc.pid, sig)
-        except (ProcessLookupError, PermissionError, OSError) as exc:
+        except OSError as exc:
             if log:
                 log.write(f"[local] could not signal job group: {exc}\n")
             break

--- a/utils/runmu2e.py
+++ b/utils/runmu2e.py
@@ -9,7 +9,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-import tarfile
 import time
 from pathlib import Path
 
@@ -42,14 +41,11 @@ from utils.samweb_wrapper import locate_file_strict, locate_files_strict
 def _job_index_from_fname(fname):
     """Parse (job_index, sequencer) from a Mu2e fname's sequencer field.
     Returns (0, sequencer) for all-zero sequencers (parent-tarball convention).
-    Raises RuntimeError on a fname that isn't a 6-field Mu2e file/tarball."""
-    try:
-        n = Mu2eName.parse(Path(fname).name)
-    except ValueError as exc:
-        raise RuntimeError(f"Invalid Mu2e fname: {fname}: {exc}")
+    Raises ValueError on a fname that isn't a 6-field Mu2e file/tarball."""
+    n = Mu2eName.parse(Path(fname).name)
     sequencer = n.sequencer
     if sequencer is None:
-        raise RuntimeError(f"Invalid Mu2e fname: {fname}; no sequencer field")
+        raise ValueError(f"Invalid Mu2e fname: {fname}; no sequencer field")
     stripped = sequencer.lstrip('0')
     return (int(stripped) if stripped else 0), sequencer
 
@@ -98,17 +94,14 @@ def _code_root_from(args):
 def _extract_simjob_setup(tarball, jp=None, code_root=None):
     """Read the setup-script path from a cnf.*.tar's jobpars.json (via
     Mu2eJobPars — pass a pre-built instance to avoid re-parsing the
-    tarball), resolve it through `resolve_setup`, re-raising with context
-    on failure.
+    tarball), resolve it through `resolve_setup`. Failures propagate: the
+    traceback (TarError/OSError from the tarball read, ValueError from
+    resolve_setup) already names the tarball.
     """
-    try:
-        jp = jp if jp is not None else Mu2eJobPars(tarball)
-        setup = resolve_setup(jp.setup(), code_root=code_root)
-        print(f"Job setup script: {setup}")
-        return setup
-    except (tarfile.TarError, KeyError, FileNotFoundError, OSError) as e:
-        print(f"ERROR: Failed to get job setup information from {tarball}: {e}")
-        raise
+    jp = jp if jp is not None else Mu2eJobPars(tarball)
+    setup = resolve_setup(jp.setup(), code_root=code_root)
+    print(f"Job setup script: {setup}")
+    return setup
 
 def replace_file_extensions(input_str, first_field, last_field):
     """Replace the tier and extension fields of a Mu2e dot-name."""
@@ -184,6 +177,25 @@ def proto_for_inloc(inloc):
         return 'file'
     return 'root'
 
+def _stage_inputs_locally(all_files, tarball, job_index_num):
+    """Copy every input into ./indir and return an FCL that reads from
+    there. One batch SAM locate (a mixing job has ~90 inputs); a file
+    with no usable location is an error, not a retry."""
+    fcl = write_fcl(tarball, f"dir:{os.getcwd()}/indir", 'file', job_index_num)
+    print("Starting to copy input files locally")
+    located = locate_files_strict(all_files)
+    for file in all_files:
+        locations = located.get(file)
+        if not locations or 'location_type' not in locations[0]:
+            raise RuntimeError(f"Could not detect location for file: {file}")
+        file_inloc = locations[0]['location_type']
+        print(f"Detected location of {file}: {file_inloc}")
+        print(f"Copying {file} from {file_inloc}")
+        _fetch_file_local(file, src_location=file_inloc)
+    run(f"mkdir indir; mv *.art indir/", shell=True)
+    return fcl
+
+
 def process_jobdef(jobdesc, fname, args):
     """Process a job in normal mode.
 
@@ -194,8 +206,8 @@ def process_jobdef(jobdesc, fname, args):
 
     try:
         job_index, _ = _job_index_from_fname(fname)
-    except RuntimeError as e:
-        fail(f"Error: {e}")
+    except ValueError as e:
+        fail(f"Error: Invalid Mu2e fname: {fname}: {e}")
 
     # Global job index -> entry's cnf-local index
     jobdesc_entry, job_index_num = resolve_entry_index(jobdesc, job_index)
@@ -248,29 +260,7 @@ def process_jobdef(jobdesc, fname, args):
     # Stash files are on CVMFS and resilient files use xrootd — no local copy needed
     if copy_input and infiles.strip() and inloc not in ("none", "stash", "resilient"):
         print(f"Copying input files locally from {inloc}: {infiles}")
-        fcl = write_fcl(tarball, f"dir:{os.getcwd()}/indir", 'file', job_index_num)
-
-        # Batch-locate everything in one SAM round-trip first (a mixing
-        # job has ~90 inputs); per-file fallback keeps error semantics.
-        print("Starting to copy input files locally")
-        located = {}
-        try:
-            result = locate_files_strict(all_files)
-            if isinstance(result, dict):
-                located = result
-        except Exception:
-            pass
-        for file in all_files:
-            locations = located.get(file)
-            if not isinstance(locations, list) or not locations:
-                locations = locate_file_strict(file)
-            if not locations or 'location_type' not in locations[0]:
-                raise RuntimeError(f"Could not detect location for file: {file}")
-            file_inloc = locations[0]['location_type']
-            print(f"Detected location of {file}: {file_inloc}")
-            print(f"Copying {file} from {file_inloc}")
-            _fetch_file_local(file, src_location=file_inloc)
-        run(f"mkdir indir; mv *.art indir/", shell=True)
+        fcl = _stage_inputs_locally(all_files, tarball, job_index_num)
         print(f"FCL: {fcl}")
     else:
         proto = proto_for_inloc(inloc)

--- a/utils/samweb_wrapper.py
+++ b/utils/samweb_wrapper.py
@@ -7,14 +7,15 @@ Callers must not hand-write "dh.dataset ..." / "defname: ..." strings;
 they call a named query method, or build the string with a q_* helper
 when the query itself is an argument (e.g. create_definition).
 
-Error-mode policy:
-- Named query methods (files_in_dataset, dataset_file_count, ...) fail
-  loud: a SAM outage raises instead of masquerading as an empty/zero
-  result.
-- Legacy generic passthroughs (list_files, count_files, ...) keep their
-  historical swallow-and-default behavior; some callers rely on it
-  (e.g. prod_utils uses describe_definition() == '' as an existence
-  check).
+Error-mode policy: every method fails loud. A SAM outage, expired
+token or malformed query raises (samweb_client.exceptions.Error or a
+subclass) instead of masquerading as an empty/zero result. An empty
+return means SAM answered "no files" / "no locations", nothing else.
+The one exception is locate_file(), which maps FileNotFound to "" —
+a file SAM does not know has no location, and its callers use that
+as an existence probe. definition_creation_date() is a documented
+dashboard fail-soft: a missing date is None, but only for SAM-raised
+errors.
 """
 
 import functools
@@ -24,6 +25,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from samweb_client import SAMWebClient #type: ignore
+from samweb_client import Error as SAMError, FileNotFound  # type: ignore
 
 
 # SAM rejects getMultipleMetadata outright above this many names
@@ -126,32 +128,25 @@ class SAMWebWrapper:
         self.client = SAMWebClient(experiment=experiment)
     
     def count_files(self, query: str) -> int:
-        """Count files matching a query (equivalent to samweb count-files)."""
-        try:
-            return self.client.countFiles(query)
-        except Exception as e:
-            print(f"Error counting files: {e}")
-            return 0
-    
-    
+        """Count files matching a query (equivalent to samweb count-files).
+        Raises on SAM errors."""
+        return self.client.countFiles(query)
+
     def list_files(self, query: str) -> List[str]:
-        """List files matching a query (equivalent to samweb list-files)."""
-        try:
-            return self.client.listFiles(query)
-        except Exception as e:
-            print(f"Error listing files: {e}")
-            return []
-    
+        """List files matching a query (equivalent to samweb list-files).
+        Raises on SAM errors; [] means SAM matched nothing."""
+        return self.client.listFiles(query)
+
     def locate_file(self, filename: str) -> str:
-        """Locate a file (equivalent to samweb locate-file)."""
+        """First location of a file (equivalent to samweb locate-file),
+        or "" when the file is unknown to SAM or has no locations —
+        the existence-probe contract json2jobdef's pushout path uses.
+        Every other SAM error (outage, auth) raises."""
         try:
             locations = self.client.locateFile(filename)
-            if locations:
-                return locations[0]  # Return first location
+        except FileNotFound:
             return ""
-        except Exception as e:
-            print(f"Error locating file {filename}: {e}")
-            return ""
+        return locations[0] if locations else ""
     
     def create_definition(self, definition_name: str, query: str) -> None:
         """Create a definition (equivalent to samweb create-definition).
@@ -165,40 +160,30 @@ class SAMWebWrapper:
         self.client.deleteDefinition(definition_name)
     
     def describe_definition(self, definition_name: str) -> str:
-        """Describe a definition (equivalent to samweb describe-definition)."""
-        try:
-            return self.client.descDefinition(definition_name)
-        except Exception as e:
-            print(f"Error describing definition {definition_name}: {e}")
-            return ""
+        """Describe a definition (equivalent to samweb describe-definition).
+        Raises on SAM errors (DefinitionNotFound included)."""
+        return self.client.descDefinition(definition_name)
     
     def list_definition_files(self, definition_name: str, availability: str = "anylocation") -> List[str]:
         """List files in a definition (equivalent to samweb list-definition-files).
-        availability constrains e.g. to 'anylocation' or 'physical'."""
-        try:
-            return self.client.listFiles(_q_definition_files(definition_name, availability))
-        except Exception as e:
-            print(f"Error listing definition files for {definition_name}: {e}")
-            return []
+        availability constrains e.g. to 'anylocation' or 'physical'.
+        Raises on SAM errors; [] means the definition is empty."""
+        return self.client.listFiles(_q_definition_files(definition_name, availability))
 
     def first_file_in_definition(self, definition_name: str,
                                  availability: str = "anylocation") -> Optional[str]:
         """First file of a SAM definition without transferring the full
         list (streamed listFiles, closed after one name — a dataset can
-        hold 100k files). Returns None on SAM errors or an empty
-        definition, matching list_definition_files' swallow semantics."""
+        hold 100k files). Returns None for an empty definition; raises
+        on SAM errors."""
+        stream = self.client.listFiles(
+            _q_definition_files(definition_name, availability), stream=True)
         try:
-            stream = self.client.listFiles(
-                _q_definition_files(definition_name, availability), stream=True)
-            try:
-                return next(iter(stream), None)
-            finally:
-                close = getattr(stream, 'close', None)
-                if close:
-                    close()
-        except Exception as e:
-            print(f"Error listing definition files for {definition_name}: {e}")
-            return None
+            return next(iter(stream), None)
+        finally:
+            close = getattr(stream, 'close', None)
+            if close:
+                close()
 
     def file_sizes_in_dataset(self, dataset: str) -> Dict[str, int]:
         """{filename: file_size} for a dataset via one list-files
@@ -209,22 +194,20 @@ class SAMWebWrapper:
                 for fi in self.client.listFiles(dimensions=q, fileinfo=True)}
 
     def get_metadata(self, filename: str) -> Dict:
-        """Get metadata for a file (equivalent to samweb get-metadata)."""
-        try:
-            return self.client.getMetadata(filename)
-        except Exception as e:
-            print(f"Error getting metadata for {filename}: {e}")
-            return {}
+        """Get metadata for a file (equivalent to samweb get-metadata).
+        Raises on SAM errors (FileNotFound included)."""
+        return self.client.getMetadata(filename)
 
     def definition_creation_date(self, defname: str) -> Optional[datetime]:
         """Creation time of a SAM definition as a naive datetime, or None
         if unavailable. Prefers the structured JSON describe, falls back
         to parsing the text rendering (older servers). Fail-soft: an
-        unknown date is treated as absent, not fatal, by dashboards."""
+        unknown date is treated as absent, not fatal, by dashboards —
+        but only for SAM-raised errors; anything else propagates."""
         info = None
         try:
             info = self.client.descDefinitionDict(defname)
-        except Exception:
+        except SAMError:
             pass
         if isinstance(info, dict):
             for key in ('create_time', 'creation_date'):
@@ -232,26 +215,24 @@ class SAMWebWrapper:
                 if parsed:
                     return parsed
         # Text fallback: "Creation Date: 2025-09-03T11:46:14+00:00"
-        match = re.search(r'Creation Date:\s+(.+)', self.describe_definition(defname))
+        try:
+            text = self.describe_definition(defname)
+        except SAMError:
+            return None
+        match = re.search(r'Creation Date:\s+(.+)', text)
         return _parse_sam_datetime(match.group(1)) if match else None
     
     def file_lineage(self, filename: str, lineage_type: str = 'parents') -> List[str]:
         """Get file lineage via SAM client getFileLineage.
         lineage_type: 'parents', 'children', 'ancestors', 'descendants',
-        or 'rawancestors'."""
-        try:
-            result = self.client.getFileLineage(lineage_type, filename)
-            return [item['file_name'] for item in result if 'file_name' in item]
-        except Exception as e:
-            print(f"Error getting file lineage {lineage_type} for {filename}: {e}")
-            return []
+        or 'rawancestors'. Raises on SAM errors; [] means SAM recorded
+        no lineage of that kind (e.g. a primary has no parents)."""
+        result = self.client.getFileLineage(lineage_type, filename)
+        return [item['file_name'] for item in result if 'file_name' in item]
 
     # -----------------------------------------------------------------
-    # Named queries — fail loud.
-    # Unlike the legacy passthroughs above, these do NOT swallow
-    # exceptions: a SAM outage raises instead of masquerading as an
-    # empty/zero result. Callers that can tolerate absence handle it
-    # themselves, visibly.
+    # Named queries. Like everything above, these raise on SAM errors;
+    # callers that can tolerate absence handle it themselves, visibly.
     # -----------------------------------------------------------------
 
     def files_in_dataset(self, dataset: str, with_events: bool = False,
@@ -284,12 +265,10 @@ class SAMWebWrapper:
         """Files that are parents of `filename`, excluding the etc.*.txt
         bookkeeping entries (same filter famtree.get_parents applies).
 
-        Fail-loud twin of file_lineage(filename, 'parents'), which
-        swallows every exception and returns []. For a lineage caller
-        that empty list is indistinguishable from 'this is a primary
-        with no parents' — an expired token or SAM outage would render
-        as a confident, wrong answer. Use this when you must tell
-        absence from failure."""
+        Twin of file_lineage(filename, 'parents') built on list-files
+        rather than getFileLineage; both raise on SAM errors, so an
+        expired token or SAM outage never renders as 'this is a primary
+        with no parents'."""
         parents = self.client.listFiles(_q_parents_of_file(filename))
         return [p for p in parents
                 if not (p.startswith('etc.') and p.endswith('.txt'))]
@@ -299,9 +278,9 @@ class SAMWebWrapper:
         return self.client.listFiles(_q_dataset_like(pattern, sequencer))
 
     def locate_file_strict(self, filename: str) -> List[Dict]:
-        """locate_file_full without the error swallowing — for the worker
-        fcl-generation path, where a masked SAM error must not surface as
-        a misleading 'file not found'."""
+        """Full locate record list (no first-record pick, no FileNotFound
+        mapping) — for the worker fcl-generation path, where an unknown
+        file must raise rather than read as 'no location'."""
         return self.client.locateFile(filename)
 
     def locate_files_strict(self, filenames: List[str]) -> Dict[str, List[Dict]]:

--- a/utils/stash_utils.py
+++ b/utils/stash_utils.py
@@ -75,6 +75,28 @@ def list_expected_paths(dataset: str) -> List[str]:
 # Copy
 # ---------------------------------------------------------------------------
 
+def _already_at_dest(dest: str, want: Optional[int]) -> bool:
+    """True when `dest` exists with the SAM-recorded size `want`.
+    An unknown size (None) or a missing/unstat-able file is False."""
+    if want is None:
+        return False
+    try:
+        return os.path.getsize(dest) == want
+    except OSError:
+        return False
+
+
+def _locate_src(filename: str, locations_map, source_loc: str) -> str:
+    """Source path for one file: from the batch locate result when it
+    has a record, else one per-file SAM locate. Raises ValueError /
+    RuntimeError when SAM has no usable location."""
+    locs = locations_map.get(filename)
+    if locs:
+        return path_from_sam_locations(filename, locs,
+                                      prefer_location=source_loc)
+    return sam_physical_path(filename, prefer_location=source_loc)
+
+
 class CopyResult(NamedTuple):
     """Outcome of a dataset copy: how many landed, how many did not.
 
@@ -131,17 +153,9 @@ def _copy_dataset(
     expected_sizes = file_sizes_in_dataset(dataset) if skip_existing else {}
     n_skip = 0
     if skip_existing:
-        keep = []
-        for filename in files:
-            want = expected_sizes.get(filename)
-            try:
-                if want is not None and os.path.getsize(
-                        dest_path_fn(filename)) == want:
-                    n_skip += 1
-                    continue
-            except OSError:
-                pass
-            keep.append(filename)
+        keep = [f for f in files
+                if not _already_at_dest(dest_path_fn(f), expected_sizes.get(f))]
+        n_skip = len(files) - len(keep)
         files = keep
         if verbose:
             print(f"  skipping {n_skip} file(s) already at destination")
@@ -152,7 +166,9 @@ def _copy_dataset(
     # semantics per file are unchanged.
     try:
         locations_map = locate_files_strict(files) if files else {}
-    except Exception:
+    except Exception as e:
+        print(f"  WARNING: batch SAM locate failed ({e}); falling back to "
+              f"one locate per file", file=sys.stderr)
         locations_map = {}
 
     n_ok = 0
@@ -164,13 +180,8 @@ def _copy_dataset(
 
         # Source path from SAM, preferring source_loc's location type.
         try:
-            locs = locations_map.get(filename)
-            if locs:
-                src = path_from_sam_locations(filename, locs,
-                                              prefer_location=source_loc)
-            else:
-                src = sam_physical_path(filename, prefer_location=source_loc)
-        except Exception as e:
+            src = _locate_src(filename, locations_map, source_loc)
+        except (ValueError, RuntimeError) as e:
             print(f"  SKIP {filename}: could not locate ({e})", file=sys.stderr)
             n_fail += 1
             continue

--- a/utils/submission_ledger.py
+++ b/utils/submission_ledger.py
@@ -155,37 +155,45 @@ def _connect(db_path):
     # 3.25 (deployed: 3.34.1). PRAGMA-guarded/idempotent — a fresh DB
     # from _SCHEMA is left alone.
     for table in ('submissions', 'campaigns'):
-        cols = [r[1] for r in con.execute(f'PRAGMA table_info({table})')]
-        if 'map_path' in cols and 'origin' not in cols:
-            try:
-                con.execute(
-                    f'ALTER TABLE {table} RENAME COLUMN map_path TO origin')
-            except sqlite3.OperationalError as exc:
-                # Two _connect calls can race check-then-act above: a
-                # cron tick, a manual command, and the write MCP server
-                # can all touch the same never-migrated ledger in one
-                # minute. Both PRAGMA checks can see map_path before
-                # either ALTER commits; the loser's ALTER then fails with
-                # "no such column: map_path" — not SQLITE_BUSY, so
-                # timeout=30 busy-retry doesn't cover it. Re-check: if
-                # origin exists now, the other side already migrated it.
-                cols_now = [r[1] for r in
-                           con.execute(f'PRAGMA table_info({table})')]
-                if 'origin' in cols_now:
-                    pass
-                elif 'readonly database' in str(exc):
-                    # Production ledger is world-readable but
-                    # mu2epro-owned (0444 to others); a non-mu2epro
-                    # reader hits this on the ALTER even though every
-                    # other statement is a no-op. Leave it un-migrated
-                    # and let ledger_ro's map_path->origin shim carry
-                    # readers across the gap; a writer migrates it on
-                    # its next connect.
-                    pass
-                else:
-                    raise  # genuinely broken schema / locked / corrupt DB
+        _migrate_map_path(con, table)
     con.commit()
     return con
+
+
+def _columns(con, table):
+    return [r[1] for r in con.execute(f'PRAGMA table_info({table})')]
+
+
+def _migrate_map_path(con, table):
+    """Rename `table`.map_path -> origin if the old column is still there.
+
+    Two _connect calls can race check-then-act: a cron tick, a manual
+    command, and the write MCP server can all touch the same
+    never-migrated ledger in one minute. Both PRAGMA checks can see
+    map_path before either ALTER commits; the loser's ALTER then fails
+    with "no such column: map_path" — not SQLITE_BUSY, so timeout=30
+    busy-retry doesn't cover it. Re-check after a failure: if origin
+    exists now, the other side already migrated it.
+
+    A "readonly database" failure is also tolerated: the production
+    ledger is world-readable but mu2epro-owned (0444 to others); a
+    non-mu2epro reader hits this on the ALTER even though every other
+    statement is a no-op. Leave it un-migrated and let ledger_ro's
+    map_path->origin shim carry readers across the gap; a writer
+    migrates it on its next connect. Anything else is a genuinely
+    broken schema / locked / corrupt DB and propagates.
+    """
+    cols = _columns(con, table)
+    if 'map_path' not in cols or 'origin' in cols:
+        return
+    try:
+        con.execute(f'ALTER TABLE {table} RENAME COLUMN map_path TO origin')
+    except sqlite3.OperationalError as exc:
+        if 'origin' in _columns(con, table):
+            return
+        if 'readonly database' in str(exc):
+            return
+        raise
 
 
 def _now():

--- a/utils/submissions.py
+++ b/utils/submissions.py
@@ -111,7 +111,7 @@ def verify_row(row, sam_lister=files_in_dataset):
     return missing, partial
 
 
-def _draining_expected(camp, datasets, job_pars, count_fn):
+def _draining_expected(camp, datasets, job_pars, count_fn, failures=None):
     """Denominators for one DRAINING campaign's output datasets.
 
     A draining campaign has no njobs — its input dataset is still
@@ -129,8 +129,17 @@ def _draining_expected(camp, datasets, job_pars, count_fn):
     suffix, and FlatGamma is a prefix of FlatGammaCalo. A cnf that
     suffixes its outputs (`{desc}-KL`) fails the check and keeps its
     "—", the correct answer rather than a fabricated one.
+
+    A dataset whose output mapping or input count FAILS (as opposed to
+    one that simply isn't this campaign's) contributes nothing AND is
+    recorded in `failures` under "<tarball> [<dataset>]" -> reason, the
+    same dict ledger_expected returns, so status reports the gap
+    instead of silently rendering "—".
     """
     pattern = camp['entry']['input_pattern']
+    tarball = camp['tarball']
+    if failures is None:
+        failures = {}
     out = {}
     for ds in datasets:
         try:
@@ -149,13 +158,15 @@ def _draining_expected(camp, datasets, job_pars, count_fn):
         try:
             produced = {_dataset_of(o)
                         for o in expected_outputs_for(probe, job_pars)}
-        except Exception:
+        except (ValueError, KeyError, RuntimeError) as e:
+            failures[f"{tarball} [{ds}]"] = f"output mapping failed: {e}"
             continue
         if ds not in produced:
             continue
         try:
             out[ds] = count_fn(candidate)
-        except Exception:
+        except (ValueError, KeyError, RuntimeError) as e:
+            failures[f"{tarball} [{ds}]"] = f"input count failed for {candidate}: {e}"
             continue
     return out
 
@@ -194,44 +205,32 @@ def ledger_expected(db_path, dsconfs=None, *, datasets=None,
     indices. failures maps tarball -> reason for campaigns that
     couldn't be resolved, contributing nothing rather than a guessed
     denominator; a failed campaign's dataset stays unknown since its
-    name was what the tarball would have supplied.
+    name was what the tarball would have supplied. A draining
+    campaign whose per-dataset mapping or input count fails is
+    recorded under "<tarball> [<dataset>]" (see _draining_expected).
     """
     expected = {}
     failures = {}
     resolved = {}          # tarball -> [datasets], or None when unresolvable
     pars = {}              # draining only: tarball -> Mu2eJobPars, or None
-    for camp in submission_ledger.all_campaigns(db_path):
-        tarball = camp['tarball']
-        entry = camp.get('entry') or {}
-        njobs = entry.get('njobs')
-        draining = is_draining(entry)
-        # A draining campaign has no njobs by definition; skipped
-        # unless the caller named the datasets it cares about, since
-        # its denominators cost one SAM count apiece.
-        if not njobs and not (draining and datasets):
-            continue
-        if dsconfs is not None:
+
+    def _resolve_draining_pars(tarball):
+        """Mu2eJobPars for a draining campaign's tarball, memoised; None
+        (and a failures entry) when the tarball cannot be resolved."""
+        if tarball not in pars:
             try:
-                if Mu2eName.parse(tarball).dsconf not in dsconfs:
-                    continue
-            except ValueError:
-                continue
-        if draining:
-            if tarball not in pars:
-                try:
-                    path = locate(tarball)
-                    if not path:
-                        raise RuntimeError("tarball not locatable")
-                    pars[tarball] = Mu2eJobPars(path)
-                except Exception as e:
-                    failures[tarball] = str(e)
-                    pars[tarball] = None
-            if pars[tarball] is None:
-                continue
-            for ds, n in _draining_expected(camp, datasets, pars[tarball],
-                                            count_fn).items():
-                expected[ds] = max(expected.get(ds, 0), n)
-            continue
+                path = locate(tarball)
+                if not path:
+                    raise RuntimeError("tarball not locatable")
+                pars[tarball] = Mu2eJobPars(path)
+            except Exception as e:
+                failures[tarball] = str(e)
+                pars[tarball] = None
+        return pars[tarball]
+
+    def _resolve_output_datasets(tarball, njobs):
+        """Output dataset names of a windowed campaign's tarball, memoised;
+        None (and a failures entry) when the tarball cannot be resolved."""
         if tarball not in resolved:
             try:
                 path = locate(tarball)
@@ -245,7 +244,39 @@ def ledger_expected(db_path, dsconfs=None, *, datasets=None,
             except Exception as e:
                 failures[tarball] = str(e)
                 resolved[tarball] = None
-        out_datasets = resolved[tarball]
+        return resolved[tarball]
+
+    def _dsconf_ok(tarball):
+        """True when no dsconf filter is set, or the tarball's dsconf is
+        in it. An unparseable tarball name never passes a filter."""
+        if dsconfs is None:
+            return True
+        try:
+            return Mu2eName.parse(tarball).dsconf in dsconfs
+        except ValueError:
+            return False
+
+    for camp in submission_ledger.all_campaigns(db_path):
+        tarball = camp['tarball']
+        entry = camp.get('entry') or {}
+        njobs = entry.get('njobs')
+        draining = is_draining(entry)
+        # A draining campaign has no njobs by definition; skipped
+        # unless the caller named the datasets it cares about, since
+        # its denominators cost one SAM count apiece.
+        if not njobs and not (draining and datasets):
+            continue
+        if not _dsconf_ok(tarball):
+            continue
+        if draining:
+            jp = _resolve_draining_pars(tarball)
+            if jp is None:
+                continue
+            for ds, n in _draining_expected(camp, datasets, jp, count_fn,
+                                            failures).items():
+                expected[ds] = max(expected.get(ds, 0), n)
+            continue
+        out_datasets = _resolve_output_datasets(tarball, njobs)
         if out_datasets is None:
             continue
         for ds in out_datasets:
@@ -344,6 +375,16 @@ def draining_state(camp, db_path, *,
             'parked': parked, 'pending': pending}
 
 
+# dCache locality -> which _gate_batch bucket a file lands in. Any state
+# not listed here (ERROR, LOST, UNAVAILABLE, a missing entry, ...) is
+# "residency unknown" and raises — fail closed, never dispatch on it.
+_LOCALITY_BUCKET = {
+    'ONLINE': 'dispatch',
+    'ONLINE_AND_NEARLINE': 'dispatch',
+    'NEARLINE': 'tape_only',
+}
+
+
 def _gate_batch(entry, candidates, *,
                 locality=_default_locality,
                 metadata_fn=metadata_for_files,
@@ -381,7 +422,7 @@ def _gate_batch(entry, candidates, *,
     by_ds = {}
     for f in old_enough:
         by_ds.setdefault(_dataset_of(f), []).append(f)
-    dispatch, tape_only = [], []
+    buckets = {'dispatch': [], 'tape_only': []}
     for ds, fl in sorted(by_ds.items()):
         mdh_loc = _LOC_TO_MDH.get(dataset_location(ds))
         if mdh_loc is None:
@@ -389,14 +430,12 @@ def _gate_batch(entry, candidates, *,
         states = locality(mdh_loc, fl)
         for f in fl:
             st = states.get(f, 'ERROR')
-            if st in ('ONLINE', 'ONLINE_AND_NEARLINE'):
-                dispatch.append(f)
-            elif st == 'NEARLINE':
-                tape_only.append(f)
-            else:
+            bucket = _LOCALITY_BUCKET.get(st)
+            if bucket is None:
                 raise RuntimeError(f"locality {st!r} for {f} — "
                                    f"residency unknown (fail closed)")
-    return dispatch, young, tape_only
+            buckets[bucket].append(f)
+    return buckets['dispatch'], young, buckets['tape_only']
 
 
 def _request_prestage(files, runner=subprocess.run):
@@ -1561,217 +1600,243 @@ def _run_pass(args):
         sys.exit(2)
 
 
+def _parse_resubmit_payload(args, row):
+    """Indices or files to re-fire for `row`, from --files / --indices /
+    --indices-file. Exits (same messages as before) on a parse error,
+    on a --files/--indices mismatch with the row's kind, or an empty
+    selection."""
+    try:
+        if args.files is not None:
+            payload = submit.parse_files(args.files)
+            if not is_draining(row['entry']):
+                sys.exit(f"submissions: row {args.row_id} is an index "
+                         f"row — use --indices, not --files")
+        else:
+            payload = submit.parse_indices(args.indices,
+                                           args.indices_file)
+            if is_draining(row['entry']):
+                sys.exit(f"submissions: row {args.row_id} is a "
+                         f"draining (file-keyed) row — use --files, "
+                         f"not --indices")
+    except (ValueError, OSError) as e:
+        sys.exit(f"submissions: {e}")
+    if not payload:
+        sys.exit("submissions: nothing to resubmit (empty selection)")
+    return payload
+
+
+def _verb_status(args, db):
+    print(f"queue cap in effect: {resolve_cap(None)}")
+    print_status(db)
+
+
+def _verb_set_slice(args, db):
+    _acquire_lock(db)
+    try:
+        old = submission_ledger.set_campaign_slice(
+            db, args.camp_id, args.slice_size)
+    except ValueError as e:
+        sys.exit(f"submissions: {e}")
+    print(f"campaign {args.camp_id}: slice_size {old} -> "
+          f"{args.slice_size} (applies from the next tick)")
+
+
+def _verb_set_memory(args, db):
+    _acquire_lock(db)
+    try:
+        old = submission_ledger.set_campaign_memory(
+            db, args.camp_id, args.memory)
+    except ValueError as e:
+        sys.exit(f"submissions: {e}")
+    print(f"campaign {args.camp_id}: memory {old or 'unset'} -> "
+          f"{args.memory} (applies from the next tick; rows already "
+          f"submitted keep their own entry, so their recoveries use "
+          f"the {RECOVERY_MEMORY} floor)")
+
+
+def _verb_set_entry(args, db):
+    _acquire_lock(db)
+    # Read the state BEFORE the write: on a settled campaign the
+    # ledger deliberately leaves the campaign snapshot alone and
+    # edits only the open rows, so claiming the campaign changed
+    # would misreport what happened.
+    was = next((c for c in submission_ledger.all_campaigns(db)
+                if c['id'] == args.camp_id), None)
+    live = was is not None and was['state'] in ('active', 'paused')
+    try:
+        old, rows = submission_ledger.set_campaign_entry_key(
+            db, args.camp_id, args.key, args.value,
+            include_open_rows=args.include_open_rows)
+    except ValueError as e:
+        sys.exit(f"submissions: {e}")
+    if live:
+        print(f"campaign {args.camp_id}: {args.key} {old or 'unset'} -> "
+              f"{args.value} (applies from the next tick)")
+    else:
+        print(f"campaign {args.camp_id} is {was['state']}: campaign "
+              f"snapshot left unchanged (no future slice reads it); "
+              f"{args.key} set to {args.value} on its open rows only")
+    if args.include_open_rows:
+        print(f"  rows updated: "
+              f"{', '.join(str(r) for r in rows) if rows else 'none'}")
+    else:
+        print("  rows already submitted keep their own entry; pass "
+              "--include-open-rows to reach their recoveries")
+
+
+def _verb_reconcile(args, db):
+    _acquire_lock(db)
+    note = args.note or ('operator reconcile: jobsub_q checked, '
+                         'window free')
+    try:
+        was = submission_ledger.reconcile_row(db, args.row_id, note)
+    except ValueError as e:
+        sys.exit(f"submissions: {e}")
+    print(f"row {args.row_id}: {was} -> reconciled ({note}). Its "
+          f"indices no longer block a campaign slice; "
+          f"`submissions resume <ID>` to restart the campaign.")
+
+
+def _verb_resubmit(args, db):
+    row = submission_ledger.row_by_id(db, args.row_id)
+    if row is None:
+        sys.exit(f"submissions: no ledger row {args.row_id} in {db}")
+    payload = _parse_resubmit_payload(args, row)
+
+    # Lock BEFORE the overlap scan, not after: the scan and the
+    # submit must be one atomic operation against the ledger, same
+    # as every mutating tick (_acquire_lock: "both passing the
+    # drain gate before either closes a row = double submit").
+    # Scanning outside the lock would let a concurrent `submissions
+    # run` reserve a window AFTER this scan sees it clear and
+    # BEFORE this submits into it — the crash-window race the
+    # ledger reservation protocol exists to close.
+    if not args.dry_run:
+        _acquire_lock(db)
+
+    blocking = _rows_blocking_indices(db, row['tarball'], payload)
+    if blocking:
+        sys.exit(
+            f"submissions: refusing — row {blocking['id']} "
+            f"(state={blocking['state']}) already covers part of this "
+            f"selection for {row['tarball']}. Deterministic payloads "
+            f"mean re-sending live work duplicates physics. Check "
+            f"jobsub_q, then `submissions reconcile {blocking['id']}` "
+            f"if the window is genuinely free.")
+
+    # --indices/--indices-file only: --files is file-keyed and has
+    # no index space to bound. Nothing checks that a requested
+    # index actually belongs to `row` — a typo (e.g. row 4231's
+    # indices meant, cursor 5000 typed) sails through
+    # _rows_blocking_indices above, since nothing else covers it
+    # YET. If a child lands there and closes before the campaign's
+    # own cursor reaches it, _slice_overlaps_ledger permanently
+    # blocks the tick on that row with no CLI escape (reconcile_row
+    # refuses anything not 'failed'/'submitting' — it would need
+    # hand-edited sqlite). The cursor is the correct bound: below it
+    # is legitimate recovery of work already submitted; at or above
+    # it is ground the campaign hasn't reached yet and will submit
+    # itself.
+    if args.files is None:
+        # _live_campaign_cursor returns the ABSOLUTE bound
+        # (firstjob + cursor) — comparable directly against
+        # `payload`, which is absolute cnf indices (same space as
+        # row['indices']). None means no active/paused campaign owns
+        # this tarball's index space right now — there is no cursor
+        # to bound against, so nothing is refused here.
+        abs_cursor = _live_campaign_cursor(db, row['tarball'])
+        over = (sorted(i for i in payload if i >= abs_cursor)
+                if abs_cursor is not None else [])
+        if over:
+            sys.exit(
+                f"submissions: refusing — index(es) {over} are at "
+                f"or above the live campaign's cursor "
+                f"({abs_cursor}) for {row['tarball']}. That ground "
+                f"has not been submitted yet; a future top-up "
+                f"slice will cover it itself, and a hand-fired "
+                f"child there can permanently block the tick with "
+                f"no CLI escape. If you meant to recover work the "
+                f"campaign has ALREADY submitted, use an index "
+                f"below {abs_cursor}.")
+
+    fn = resubmit_files if args.files is not None else resubmit
+    # _guarded_submit (inside fn) returns True for ANY non-raising
+    # call — including submit_entry returning {'status': 'failed'}
+    # when jobsub_submit exits non-zero (possibly after already
+    # creating a cluster) or exits 0 with no parseable cluster id.
+    # `ok` alone can't distinguish that from a real submission, so
+    # confirm by evidence: a NEW active child row parented on this
+    # one. No such row means nothing was confirmed submitted — exit
+    # nonzero rather than let a caller's `&& next-step.sh` run on a
+    # false success. Skipped on --dry-run: submit_entry returns
+    # before touching the ledger, so there's nothing to find and
+    # nothing was promised.
+    before = {r['id'] for r in submission_ledger.open_rows(db)
+             if r['parent_id'] == row['id']}
+    ok = fn(row, payload, db, dry_run=args.dry_run,
+           origin=f"operator resubmit of row {row['id']}")
+    if not ok:
+        sys.exit(f"submissions: resubmit of row {args.row_id} FAILED")
+    if args.dry_run:
+        return
+    new_children = [r for r in submission_ledger.open_rows(db)
+                    if r['parent_id'] == row['id']
+                    and r['id'] not in before]
+    if not new_children:
+        sys.exit(
+            f"submissions: resubmit of row {args.row_id} did NOT "
+            f"confirm a submission — no new active child ledger row "
+            f"appeared. jobsub_submit likely failed (possibly after "
+            f"creating a cluster); nothing is confirmed re-fired. "
+            f"Check jobsub_q, look for a 'failed' child row on "
+            f"row {args.row_id}, and `submissions reconcile <id>` "
+            f"it before retrying.")
+    print(f"row {args.row_id}: resubmitted -> child row "
+          f"{new_children[0]['id']}")
+
+
+def _verb_manage(args, db):
+    """pause / resume / cancel / complete — one handler, verb from args."""
+    _acquire_lock(db)
+    try:
+        manage_campaign(db, args.camp_id, args.verb,
+                        note=getattr(args, 'note', None),
+                        close_rows=getattr(args, 'close_rows', False))
+    except ValueError as e:
+        sys.exit(f"submissions: {e}")
+
+
+def _verb_run(args, db):
+    if not args.dry_run:
+        _acquire_lock(db)
+    _run_pass(args)
+
+
+_VERB_HANDLERS = {
+    'status': _verb_status,
+    'set-slice': _verb_set_slice,
+    'set-memory': _verb_set_memory,
+    'set-entry': _verb_set_entry,
+    'reconcile': _verb_reconcile,
+    'resubmit': _verb_resubmit,
+    'pause': _verb_manage,
+    'resume': _verb_manage,
+    'cancel': _verb_manage,
+    'complete': _verb_manage,
+    'run': _verb_run,
+}
+
+
 def main(argv=None):
     args = build_parser().parse_args(argv)
-    verb = args.verb
     # Resolved ONCE here; args.db is overwritten so every use below
     # (including inside _run_pass) sees this same value rather than
     # re-resolving and risking a second answer that disagrees.
     db = args.db = resolve_db(args)
-
-    if verb == 'status':
-        print(f"queue cap in effect: {resolve_cap(None)}")
-        print_status(db)
-        return
-
-    if verb == 'set-slice':
-        _acquire_lock(db)
-        try:
-            old = submission_ledger.set_campaign_slice(
-                db, args.camp_id, args.slice_size)
-        except ValueError as e:
-            sys.exit(f"submissions: {e}")
-        print(f"campaign {args.camp_id}: slice_size {old} -> "
-              f"{args.slice_size} (applies from the next tick)")
-        return
-
-    if verb == 'set-memory':
-        _acquire_lock(db)
-        try:
-            old = submission_ledger.set_campaign_memory(
-                db, args.camp_id, args.memory)
-        except ValueError as e:
-            sys.exit(f"submissions: {e}")
-        print(f"campaign {args.camp_id}: memory {old or 'unset'} -> "
-              f"{args.memory} (applies from the next tick; rows already "
-              f"submitted keep their own entry, so their recoveries use "
-              f"the {RECOVERY_MEMORY} floor)")
-        return
-
-    if verb == 'set-entry':
-        _acquire_lock(db)
-        # Read the state BEFORE the write: on a settled campaign the
-        # ledger deliberately leaves the campaign snapshot alone and
-        # edits only the open rows, so claiming the campaign changed
-        # would misreport what happened.
-        was = next((c for c in submission_ledger.all_campaigns(db)
-                    if c['id'] == args.camp_id), None)
-        live = was is not None and was['state'] in ('active', 'paused')
-        try:
-            old, rows = submission_ledger.set_campaign_entry_key(
-                db, args.camp_id, args.key, args.value,
-                include_open_rows=args.include_open_rows)
-        except ValueError as e:
-            sys.exit(f"submissions: {e}")
-        if live:
-            print(f"campaign {args.camp_id}: {args.key} {old or 'unset'} -> "
-                  f"{args.value} (applies from the next tick)")
-        else:
-            print(f"campaign {args.camp_id} is {was['state']}: campaign "
-                  f"snapshot left unchanged (no future slice reads it); "
-                  f"{args.key} set to {args.value} on its open rows only")
-        if args.include_open_rows:
-            print(f"  rows updated: "
-                  f"{', '.join(str(r) for r in rows) if rows else 'none'}")
-        else:
-            print("  rows already submitted keep their own entry; pass "
-                  "--include-open-rows to reach their recoveries")
-        return
-
-    if verb == 'reconcile':
-        _acquire_lock(db)
-        note = args.note or ('operator reconcile: jobsub_q checked, '
-                             'window free')
-        try:
-            was = submission_ledger.reconcile_row(db, args.row_id, note)
-        except ValueError as e:
-            sys.exit(f"submissions: {e}")
-        print(f"row {args.row_id}: {was} -> reconciled ({note}). Its "
-              f"indices no longer block a campaign slice; "
-              f"`submissions resume <ID>` to restart the campaign.")
-        return
-
-    if verb == 'resubmit':
-        row = submission_ledger.row_by_id(db, args.row_id)
-        if row is None:
-            sys.exit(f"submissions: no ledger row {args.row_id} in {db}")
-        try:
-            if args.files is not None:
-                payload = submit.parse_files(args.files)
-                if not is_draining(row['entry']):
-                    sys.exit(f"submissions: row {args.row_id} is an index "
-                             f"row — use --indices, not --files")
-            else:
-                payload = submit.parse_indices(args.indices,
-                                               args.indices_file)
-                if is_draining(row['entry']):
-                    sys.exit(f"submissions: row {args.row_id} is a "
-                             f"draining (file-keyed) row — use --files, "
-                             f"not --indices")
-        except (ValueError, OSError) as e:
-            sys.exit(f"submissions: {e}")
-        if not payload:
-            sys.exit("submissions: nothing to resubmit (empty selection)")
-
-        # Lock BEFORE the overlap scan, not after: the scan and the
-        # submit must be one atomic operation against the ledger, same
-        # as every mutating tick (_acquire_lock: "both passing the
-        # drain gate before either closes a row = double submit").
-        # Scanning outside the lock would let a concurrent `submissions
-        # run` reserve a window AFTER this scan sees it clear and
-        # BEFORE this submits into it — the crash-window race the
-        # ledger reservation protocol exists to close.
-        if not args.dry_run:
-            _acquire_lock(db)
-
-        blocking = _rows_blocking_indices(db, row['tarball'], payload)
-        if blocking:
-            sys.exit(
-                f"submissions: refusing — row {blocking['id']} "
-                f"(state={blocking['state']}) already covers part of this "
-                f"selection for {row['tarball']}. Deterministic payloads "
-                f"mean re-sending live work duplicates physics. Check "
-                f"jobsub_q, then `submissions reconcile {blocking['id']}` "
-                f"if the window is genuinely free.")
-
-        # --indices/--indices-file only: --files is file-keyed and has
-        # no index space to bound. Nothing checks that a requested
-        # index actually belongs to `row` — a typo (e.g. row 4231's
-        # indices meant, cursor 5000 typed) sails through
-        # _rows_blocking_indices above, since nothing else covers it
-        # YET. If a child lands there and closes before the campaign's
-        # own cursor reaches it, _slice_overlaps_ledger permanently
-        # blocks the tick on that row with no CLI escape (reconcile_row
-        # refuses anything not 'failed'/'submitting' — it would need
-        # hand-edited sqlite). The cursor is the correct bound: below it
-        # is legitimate recovery of work already submitted; at or above
-        # it is ground the campaign hasn't reached yet and will submit
-        # itself.
-        if args.files is None:
-            # _live_campaign_cursor returns the ABSOLUTE bound
-            # (firstjob + cursor) — comparable directly against
-            # `payload`, which is absolute cnf indices (same space as
-            # row['indices']).
-            abs_cursor = _live_campaign_cursor(db, row['tarball'])
-            if abs_cursor is None:
-                # No active/paused campaign owns this tarball's index
-                # space right now — there is no cursor to bound against,
-                # so nothing is refused here.
-                pass
-            else:
-                over = sorted(i for i in payload if i >= abs_cursor)
-                if over:
-                    sys.exit(
-                        f"submissions: refusing — index(es) {over} are at "
-                        f"or above the live campaign's cursor "
-                        f"({abs_cursor}) for {row['tarball']}. That ground "
-                        f"has not been submitted yet; a future top-up "
-                        f"slice will cover it itself, and a hand-fired "
-                        f"child there can permanently block the tick with "
-                        f"no CLI escape. If you meant to recover work the "
-                        f"campaign has ALREADY submitted, use an index "
-                        f"below {abs_cursor}.")
-
-        fn = resubmit_files if args.files is not None else resubmit
-        # _guarded_submit (inside fn) returns True for ANY non-raising
-        # call — including submit_entry returning {'status': 'failed'}
-        # when jobsub_submit exits non-zero (possibly after already
-        # creating a cluster) or exits 0 with no parseable cluster id.
-        # `ok` alone can't distinguish that from a real submission, so
-        # confirm by evidence: a NEW active child row parented on this
-        # one. No such row means nothing was confirmed submitted — exit
-        # nonzero rather than let a caller's `&& next-step.sh` run on a
-        # false success. Skipped on --dry-run: submit_entry returns
-        # before touching the ledger, so there's nothing to find and
-        # nothing was promised.
-        before = {r['id'] for r in submission_ledger.open_rows(db)
-                 if r['parent_id'] == row['id']}
-        ok = fn(row, payload, db, dry_run=args.dry_run,
-               origin=f"operator resubmit of row {row['id']}")
-        if not ok:
-            sys.exit(f"submissions: resubmit of row {args.row_id} FAILED")
-        if args.dry_run:
-            return
-        new_children = [r for r in submission_ledger.open_rows(db)
-                        if r['parent_id'] == row['id']
-                        and r['id'] not in before]
-        if not new_children:
-            sys.exit(
-                f"submissions: resubmit of row {args.row_id} did NOT "
-                f"confirm a submission — no new active child ledger row "
-                f"appeared. jobsub_submit likely failed (possibly after "
-                f"creating a cluster); nothing is confirmed re-fired. "
-                f"Check jobsub_q, look for a 'failed' child row on "
-                f"row {args.row_id}, and `submissions reconcile <id>` "
-                f"it before retrying.")
-        print(f"row {args.row_id}: resubmitted -> child row "
-              f"{new_children[0]['id']}")
-        return
-
-    if verb in ('pause', 'resume', 'cancel', 'complete'):
-        _acquire_lock(db)
-        try:
-            manage_campaign(db, args.camp_id, verb,
-                            note=getattr(args, 'note', None),
-                            close_rows=getattr(args, 'close_rows', False))
-        except ValueError as e:
-            sys.exit(f"submissions: {e}")
-        return
-
-    # verb == 'run'
-    if not args.dry_run:
-        _acquire_lock(db)
-    _run_pass(args)
+    handler = _VERB_HANDLERS.get(args.verb)
+    if handler is None:
+        sys.exit(f"submissions: unknown verb {args.verb!r}")
+    handler(args, db)
 
 
 if __name__ == '__main__':

--- a/utils/submit.py
+++ b/utils/submit.py
@@ -206,7 +206,7 @@ def _attach_cluster(row_id, result, options):
             cluster_id=result['cluster_id'])
         print(f"Ledger: row {row_id} attached to cluster "
               f"{result['cluster_id']} in {options.ledger_db}")
-    except Exception as e:
+    except (sqlite3.Error, OSError) as e:
         print(f"WARNING: ledger attach failed ({e}) — the submission DID "
               f"go through (cluster {result['cluster_id']}). Row {row_id} "
               f"is still 'submitting'; set it active by hand: "
@@ -224,7 +224,7 @@ def _fail_reservation(row_id, result, options):
             f"submit failed (status={result.get('status')}); window NOT "
             f"proven free — check jobsub_q before reusing these indices")
         print(f"Ledger: row {row_id} marked failed in {options.ledger_db}")
-    except Exception as e:
+    except (sqlite3.Error, OSError) as e:
         print(f"WARNING: could not mark row {row_id} failed ({e}); it "
               f"remains 'submitting' in {options.ledger_db}")
 
@@ -243,30 +243,30 @@ def _log_submission(firstjob, jobset, result, options, files=None):
     origin (manual, cron slice, recovery resubmit). Never raises: the
     attempt already happened, so a log problem must not crash the
     submit."""
+    if files is not None:
+        idx_line = (f"files: {len(files)} "
+                    f"[{files[0]} .. {files[-1]}]")
+    else:
+        absolute = [firstjob + i for i in jobset]
+        idx_line = (f"indices: {len(absolute)} absolute "
+                    f"[{absolute[0]}..{absolute[-1]}]"
+                    if absolute else "indices: none")
+    block = '\n'.join([
+        f"=== {datetime.now(timezone.utc).isoformat(timespec='seconds')} "
+        f"user={getpass.getuser()} status={result['status']}",
+        f"origin={options.origin} tarball={result['tarball']}",
+        idx_line,
+        f"cluster={result['cluster_id']} "
+        f"jobsub_id={result.get('jobsub_id')}",
+        "--- jobsub output ---",
+        result.get('raw_output', '').rstrip(),
+        "=== end",
+        "",
+    ])
     try:
-        if files is not None:
-            idx_line = (f"files: {len(files)} "
-                        f"[{files[0]} .. {files[-1]}]")
-        else:
-            absolute = [firstjob + i for i in jobset]
-            idx_line = (f"indices: {len(absolute)} absolute "
-                        f"[{absolute[0]}..{absolute[-1]}]"
-                        if absolute else "indices: none")
-        block = '\n'.join([
-            f"=== {datetime.now(timezone.utc).isoformat(timespec='seconds')} "
-            f"user={getpass.getuser()} status={result['status']}",
-            f"origin={options.origin} tarball={result['tarball']}",
-            idx_line,
-            f"cluster={result['cluster_id']} "
-            f"jobsub_id={result.get('jobsub_id')}",
-            "--- jobsub output ---",
-            result.get('raw_output', '').rstrip(),
-            "=== end",
-            "",
-        ])
         with open(_submission_log_path(options.ledger_db), 'a') as fh:
             fh.write(block + '\n')
-    except Exception as e:
+    except OSError as e:
         print(f"WARNING: submit-log write failed ({e}) — submission "
               f"outcome unaffected (status={result['status']})")
 
@@ -418,31 +418,9 @@ def enqueue_entry(entry, *, ledger_db, slice_size, dry_run=False,
     _validate_entry_values(entry)
     _refuse_outstage_campaign(entry)
     if is_draining(entry):
-        err = _validate_draining_entry(entry)
-        if err:
-            sys.exit(f"json2jobdef: {err}")
-        tarball_path = _ensure_local_tarball(tarball_of(entry))
-        # No check_inputs: a generic cnf bakes no inputs — the tick gates
-        # each batch (residency + settling age) at dispatch. Code
-        # tarball still has to match, though.
-        _gate_code_tarball(entry, tarball_path)
-        snap = _snapshot_entry(entry, resources)
-        if dry_run:
-            print(f"[DRY RUN] would enqueue draining campaign: "
-                  f"{tarball_of(entry)} "
-                  f"pattern={entry['input_pattern']} "
-                  f"slice={slice_size}")
-            return None
-        try:
-            camp_id = submission_ledger.create_campaign(
-                ledger_db, tarball=tarball_of(entry), entry=snap,
-                slice_size=slice_size, origin=provenance)
-        except (ValueError, sqlite3.Error) as e:
-            sys.exit(f"json2jobdef: {e}")
-        print(f"Enqueued draining campaign {camp_id}: "
-              f"{tarball_of(entry)} pattern={entry['input_pattern']} "
-              f"slice={slice_size} (db {ledger_db})")
-        return camp_id
+        return _enqueue_draining(entry, ledger_db=ledger_db,
+                                 slice_size=slice_size, dry_run=dry_run,
+                                 resources=resources, provenance=provenance)
 
     tarball_path = _ensure_local_tarball(tarball_of(entry))
     ok, problems = check_inputs(str(tarball_path), inloc_of(entry))
@@ -468,15 +446,46 @@ def enqueue_entry(entry, *, ledger_db, slice_size, dry_run=False,
               f"{tarball_of(entry)} njobs={njobs} "
               f"slice={slice_size}")
         return None
+    camp_id = _create_campaign(ledger_db, entry, snap, slice_size, provenance)
+    print(f"Enqueued campaign {camp_id}: {tarball_of(entry)} "
+          f"njobs={njobs} slice={slice_size} (db {ledger_db})")
+    return camp_id
+
+
+def _enqueue_draining(entry, *, ledger_db, slice_size, dry_run,
+                      resources, provenance):
+    """Draining-entry tail of enqueue_entry (generic cnf + input_pattern)."""
+    err = _validate_draining_entry(entry)
+    if err:
+        sys.exit(f"json2jobdef: {err}")
+    tarball_path = _ensure_local_tarball(tarball_of(entry))
+    # No check_inputs: a generic cnf bakes no inputs — the tick gates
+    # each batch (residency + settling age) at dispatch. Code
+    # tarball still has to match, though.
+    _gate_code_tarball(entry, tarball_path)
+    snap = _snapshot_entry(entry, resources)
+    if dry_run:
+        print(f"[DRY RUN] would enqueue draining campaign: "
+              f"{tarball_of(entry)} "
+              f"pattern={entry['input_pattern']} "
+              f"slice={slice_size}")
+        return None
+    camp_id = _create_campaign(ledger_db, entry, snap, slice_size, provenance)
+    print(f"Enqueued draining campaign {camp_id}: "
+          f"{tarball_of(entry)} pattern={entry['input_pattern']} "
+          f"slice={slice_size} (db {ledger_db})")
+    return camp_id
+
+
+def _create_campaign(ledger_db, entry, snap, slice_size, provenance):
+    """Single home of the create_campaign call and its one-line exit on
+    a ledger/validation error (nothing has been submitted yet)."""
     try:
-        camp_id = submission_ledger.create_campaign(
+        return submission_ledger.create_campaign(
             ledger_db, tarball=tarball_of(entry), entry=snap,
             slice_size=slice_size, origin=provenance)
     except (ValueError, sqlite3.Error) as e:
         sys.exit(f"json2jobdef: {e}")
-    print(f"Enqueued campaign {camp_id}: {tarball_of(entry)} "
-          f"njobs={njobs} slice={slice_size} (db {ledger_db})")
-    return camp_id
 
 
 def _bundle_prodtools(out_path=DEFAULT_PRODTOOLS_TAR):
@@ -762,11 +771,10 @@ def submit_entry(entry, idx, options):
         output_filenames, outputs_of(entry)))
     if output_filenames:
         log_location = log_storage_location(entry)
-        try:
-            first_out = Mu2eName.parse(output_filenames[0])
-        except ValueError:
-            first_out = None
-        if first_out is not None and first_out.is_file:
+        # A cnf output that does not parse is a broken cnf: a silently
+        # skipped log scope surfaces as a 403 on the worker's log push.
+        first_out = Mu2eName.parse(output_filenames[0])
+        if first_out.is_file:
             log_fname = str(first_out.as_tier('log').with_extension('log'))
             log_scope = _jobsub_argv.storage_scope_for_file(log_fname, log_location)
             if log_scope:


### PR DESCRIPTION
…p nesting

Fail-soft paths that turned an outage into 'no data' now raise: samweb_wrapper soft methods (count/list/locate/describe/metadata/lineage), jobdef_lookup.list_jobdefs, json2jobdef._next_version (version 0 = cnf name collision), latestDatasets._dataset_exists (--skip-produced re-emit), submit log-scope parse (silent missing storage.modify), runmu2e locate_files_strict swallow, json2jobdef MaxEventsToSkip, prod_utils get_def_counts non-dict reply, jobsub_argv desc/campaign fallbacks. listNewDatasets._total_files renders '?' instead of a fabricated 0; genFilterEff counts a file only after its gencount check passes.

Narrowed ~15 'except Exception' to the types actually raised; removed redundant re-wraps (jobquery, jobdef_lookup.locate_tarball, runmu2e); missing fhicl-get no longer reads as 'no seed / no output'.

Flattened: submissions.ledger_expected/_gate_batch/main (dict dispatch), submission_ledger._migrate_map_path, submit.enqueue_entry (shared _create_campaign), runmu2e._stage_inputs_locally, json2jobdef _write_sam_inputs, jobquery main, job_common job_aux_inputs (seed-order fixture verified identical), datasetFileList._print_all, famtree, stash_utils. runjob.sh fails on tar error; install_prodtools pipefail.

Tests: 1279 unit tests pass (4 updated to assert the new fail-loud behaviour); parity_test.sh index-0 results identical to HEAD.